### PR TITLE
utility function: run_app_from_main allows PETSc command line arguments

### DIFF
--- a/apps/acoustics/1d/homogeneous/acoustics.py
+++ b/apps/acoustics/1d/homogeneous/acoustics.py
@@ -78,7 +78,5 @@ def acoustics(use_petsc=False,kernel_language='Fortran',solver_type='classic',ip
     if iplot:     pyclaw.plot.interactive_plot(outdir=outdir)
 
 if __name__=="__main__":
-    import sys
-    from pyclaw.util import _info_from_argv
-    args, kwargs = _info_from_argv(sys.argv)
-    error=acoustics(*args,**kwargs)
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(acoustics)

--- a/apps/acoustics/1d/homogeneous/acoustics_implicit.py
+++ b/apps/acoustics/1d/homogeneous/acoustics_implicit.py
@@ -147,8 +147,6 @@ def acoustics(kernel_language='Python',petscPlot=False,iplot=False,htmlplot=Fals
 
 
 if __name__=="__main__":
-    import sys
-    from petclaw.util import _info_from_argv
-    args, kwargs = _info_from_argv(sys.argv)
-    error=acoustics(**kwargs)
+    from pyclaw.util import run_app_from_main
+    error = run_app_from_main(acoustics)
     print 'Error: ',error

--- a/apps/acoustics/2d/homogeneous/acoustics.py
+++ b/apps/acoustics/2d/homogeneous/acoustics.py
@@ -74,8 +74,5 @@ def acoustics2D(iplot=False,htmlplot=False,use_petsc=False,outdir='./_output',so
 
 if __name__=="__main__":
     import sys
-    if len(sys.argv)>1:
-        from pyclaw.util import _info_from_argv
-        args, kwargs = _info_from_argv(sys.argv)
-        acoustics2D(*args,**kwargs)
-    else: acoustics2D()
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(acoustics2D)

--- a/apps/advection/1d/constant/advection.py
+++ b/apps/advection/1d/constant/advection.py
@@ -47,7 +47,5 @@ def advection(kernel_language='Python',iplot=False,htmlplot=False,use_petsc=Fals
     if iplot:     pyclaw.plot.interactive_plot(outdir=outdir)
 
 if __name__=="__main__":
-    import sys
-    from pyclaw.util import _info_from_argv
-    args, kwargs = _info_from_argv(sys.argv)
-    output=advection(*args,**kwargs)
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(advection)

--- a/apps/advection/1d/constant/advection_implicitLW.py
+++ b/apps/advection/1d/constant/advection_implicitLW.py
@@ -74,10 +74,8 @@ def advection_implicitLW(use_petsc=True,iplot=False,htmlplot=False,solver_type='
     #if iplot:     pyclaw.plot.interactive_plot(outdir=outdir)
 
 if __name__=="__main__":
-    import sys
-    if len(sys.argv)>1:
-        from pyclaw.util import _info_from_argv
-        args, kwargs = _info_from_argv(sys.argv)
-        error=advection_implicitLW(*args,**kwargs)
-        print 'Error: ',error
-    else: advection_implicitLW()
+
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(advection_implicitLW)
+    print 'Error: ',output
+

--- a/apps/advection/1d/variable/variable_coefficient_advection.py
+++ b/apps/advection/1d/variable/variable_coefficient_advection.py
@@ -78,7 +78,5 @@ def vc_advection(use_petsc=False,solver_type='classic',kernel_language='Python',
     if iplot:     pyclaw.plot.interactive_plot(outdir=outdir)
 
 if __name__=="__main__":
-    import sys
-    from pyclaw.util import _info_from_argv
-    args, kwargs = _info_from_argv(sys.argv)
-    output=vc_advection(*args,**kwargs)
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(vc_advection)

--- a/apps/advection/2d/annulus/advection_annulus.py
+++ b/apps/advection/2d/annulus/advection_annulus.py
@@ -228,13 +228,9 @@ def advection_annulus(use_petsc=False,iplot=0,htmlplot=False,outdir='./_output',
 
 
 if __name__=="__main__":
-    import sys
-    if len(sys.argv)>1:
-        from pyclaw.util import _info_from_argv
-        args, kwargs = _info_from_argv(sys.argv)
-        error=advection_annulus(*args,**kwargs)
-        print 'Error: ',error
-    else: advection_annulus()
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(advection_annulus)
+    print 'Error: ',output
 
 
 

--- a/apps/advection/2d/example1/advection.py
+++ b/apps/advection/2d/example1/advection.py
@@ -106,9 +106,5 @@ def advection2D(iplot=False,use_petsc=False,htmlplot=False,outdir='./_output',so
 
 
 if __name__=="__main__":
-    import sys
-    if len(sys.argv)>1:
-        from pyclaw.util import _info_from_argv
-        args, kwargs = _info_from_argv(sys.argv)
-        advection2D(*args,**kwargs)
-    else: advection2D()
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(advection2D)

--- a/apps/burgers/1d/burgers1D.py
+++ b/apps/burgers/1d/burgers1D.py
@@ -56,9 +56,7 @@ def burgers(use_petsc=0,kernel_language='Fortran',iplot=0,htmlplot=0,outdir='./_
 
 
 if __name__=="__main__":
-    import sys
-    from pyclaw.util import _info_from_argv
-    args, kwargs = _info_from_argv(sys.argv)
-    error=burgers(*args,**kwargs)
-    print 'Error: ',error
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(burgers)
+    print 'Error: ',output
 

--- a/apps/burgers/2d/burgers2D.py
+++ b/apps/burgers/2d/burgers2D.py
@@ -66,9 +66,5 @@ def burgers2D(iplot=False,petscPlot=True,useController=True,htmlplot=False,outdi
 
 
 if __name__=="__main__":
-    import sys
-    if len(sys.argv)>1:
-        from petclaw.util import _info_from_argv
-        args, kwargs = _info_from_argv(sys.argv)
-        burgers2D(*args,**kwargs)
-    else: burgers2D()
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(burgers2D)

--- a/apps/elasticity/1d/stegoton/stegoton.py
+++ b/apps/elasticity/1d/stegoton/stegoton.py
@@ -181,7 +181,5 @@ def stegoton(use_petsc=1,kernel_language='Fortran',solver_type='classic',iplot=0
 
 
 if __name__=="__main__":
-    import sys
-    from pyclaw.util import _info_from_argv
-    args, kwargs = _info_from_argv(sys.argv)
-    stegoton(*args,**kwargs)
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(stegoton)

--- a/apps/euler/shockbubble/shockbubble.py
+++ b/apps/euler/shockbubble/shockbubble.py
@@ -158,9 +158,5 @@ def shockbubble(use_petsc=False,iplot=False,htmlplot=False,outdir='./_output',so
     return claw.solution.q
 
 if __name__=="__main__":
-    import sys
-    if len(sys.argv)>1:
-        from pyclaw.util import _info_from_argv
-        args, kwargs = _info_from_argv(sys.argv)
-        shockbubble(*args,**kwargs)
-    else: shockbubble()
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(shockbubble)

--- a/apps/kpp/kpp.py
+++ b/apps/kpp/kpp.py
@@ -63,9 +63,5 @@ def kpp(use_petsc=False,iplot=False,htmlplot=False,outdir='./_output',solver_typ
 
 
 if __name__=="__main__":
-    import sys
-    if len(sys.argv)>1:
-        from pyclaw.util import _info_from_argv
-        args, kwargs = _info_from_argv(sys.argv)
-        kpp(*args,**kwargs)
-    else: kpp()
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(kpp)

--- a/apps/psystem/psystem.py
+++ b/apps/psystem/psystem.py
@@ -225,7 +225,5 @@ def psystem2D(use_petsc=True,solver_type='classic',iplot=False,htmlplot=False):
     if htmlplot: pyclaw.plot.html_plot()
 
 if __name__=="__main__":
-    import sys
-    from pyclaw.util import _info_from_argv
-    args, kwargs = _info_from_argv(sys.argv)
-    psystem2D(*args,**kwargs)
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(psystem2D)

--- a/apps/shallow/1d/shallow1D.py
+++ b/apps/shallow/1d/shallow1D.py
@@ -84,10 +84,8 @@ def shallow1D(use_petsc=False,kernel_language='Fortran',iplot=False,htmlplot=Fal
 
 
 if __name__=="__main__":
-    import sys
-    from pyclaw.util import _info_from_argv
-    args, kwargs = _info_from_argv(sys.argv)
-    shallow1D(*args,**kwargs)
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(shallow1D)
     
 
    

--- a/apps/shallow/2d/shallow2D.py
+++ b/apps/shallow/2d/shallow2D.py
@@ -112,14 +112,9 @@ def shallow2D(use_petsc=False,iplot=0,htmlplot=False,outdir='./_output',solver_t
 
 
 if __name__=="__main__":
-    import sys
-    if len(sys.argv)>1:
-        from pyclaw.util import _info_from_argv
-        args, kwargs = _info_from_argv(sys.argv)
-        error=shallow2D(*args,**kwargs)
-        print 'Error: ',error
-    else: shallow2D()
-
+    from pyclaw.util import run_app_from_main
+    output = run_app_from_main(shallow2D)
+    print 'Error: ', output
 
 
 

--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -26,6 +26,31 @@ import logging
 import tempfile
 import numpy as np
 
+def run_app_from_main(application):
+    r"""
+    Runs an application from apps/, automatically parsing command line keyword
+    arguments (key=value) as parameters to the application, with positional
+    arguments being passed to PETSc (if it is enabled).
+
+    Perhaps we should take the PETSc approach of having a database of PyClaw
+    options that can be queried for options on specific objects within the
+    PyClaw runtime instead of front-loading everything through the application
+    main...
+    """
+
+    # Arguments to the PyClaw should be keyword based, positional arguments
+    # will be passed to PETSc
+    petsc_args, app_kwargs = _info_from_argv(sys.argv)
+
+    if 'use_petsc' in app_kwargs and app_kwargs['use_petsc']:
+        import petsc4py
+        petsc_args = [arg.replace('--','-') for arg in sys.argv[1:] if '=' not in arg]
+        print petsc_args
+        petsc4py.init(petsc_args)
+
+    output=application(**app_kwargs)
+    return output
+
 # ============================================================================
 #  F2PY Utility Functions
 # ============================================================================


### PR DESCRIPTION
I've added a new utility function run_app_from_main that will allow PETSc command line arguments to be handled when running 'app' scripts.  There is one major caveat, I am currently dividing up command line arguments into two 'buckets',

key=value (keyword arguments)
-               (everything else)

All key=value arguments are going to the app now as keyword arguments, everything else gets passed to PETSc.  This seems like a logical division to me, since these are the 'natural' ways to communicate command line arguments to both pyclaw and PETSc.

I've run nosetests locally and run this by Matt, but it would be good for somebody from the pyclaw side of things to double-check that I'm doing things in a sane manner and that I haven't broken any assumptions.
