### PR TITLE
PETSc i/o cleanup, bug fix, da viewing disabled until petsc-3.2

### DIFF
--- a/src/petclaw/io/petsc.py
+++ b/src/petclaw/io/petsc.py
@@ -124,7 +124,8 @@ def write_petsc(solution,frame,path='./',file_prefix='claw',write_aux=False,opti
             pickle.dump({'stateno':state.stateno,'level':grid.level,
                          'names':grid.name,'lower':grid.lower,
                          'n':grid.n,'d':grid.d}, pickle_file)
-        state.q_da.view(viewer)
+#       we will reenable this bad boy when we switch over to petsc-dev
+#        state.q_da.view(viewer)
         if write_p:
             state.gpVec.view(viewer)
         else:
@@ -181,10 +182,10 @@ def read_petsc(solution,frame,path='./',file_prefix='claw',read_aux=False,option
     # this dictionary is mostly holding debugging information, only nstates is needed
     # most of this information is explicitly saved in the individual grids
     value_dict = pickle.load(pickle_file)
-    nstates   = value_dict['nstates']                    
-    ndim     = value_dict['ndim']
-    maux     = value_dict['maux']
-    meqn     = value_dict['meqn']
+    nstates    = value_dict['nstates']                    
+    ndim       = value_dict['ndim']
+    maux       = value_dict['maux']
+    meqn       = value_dict['meqn']
 
     # now set up the PETSc viewer
     if options['format'] == 'ascii':
@@ -235,20 +236,14 @@ def read_petsc(solution,frame,path='./',file_prefix='claw',read_aux=False,option
         state.t = value_dict['t']
         state.aux_global = value_dict['aux_global']
 
-        da = state._create_DA(meqn)
-        gVec = da.createGlobalVector()
-        gVec.load(viewer)
-        dim=[meqn]
-        dim.extend(grid.ng)
-        state.q = gVec.getArray().reshape(dim,order='F')
+        state.meqn=meqn
+#       DA View/Load is broken in Petsc-3.1.8, we can load/view the DA if needed in petsc-3.2
+#       state.q_da.load(viewer)
+        state.gqVec.load(viewer)
         
         if read_aux:
-            da = state._create_DA(maux)
-            gVec = da.createGlobalVector()
-            gVec.load(aux_viewer)
-            dim=[maux]; 
-            dim.extend(grid.ng)
-            state.aux = gVec.getArray().reshape(dim,order='F')
+            state.maux=maux
+            state.gauxVec.load(aux_viewer)
         
         solution.states.append(state)
 


### PR DESCRIPTION
This is to fix a bug Manuel found, I also removed some redundant commands and disabled DA viewing/loading (all we need is the Vec, we store important metadata in the pickle file).
