### PR TITLE
3D fortran updated with forall constructs

### DIFF
--- a/src/fortran/3d/classic/flux3.f
+++ b/src/fortran/3d/classic/flux3.f
@@ -178,7 +178,7 @@ c
           qadd(m,i) = 0.d0
           fadd(m,i) = 0.d0
       end forall
-      forall (m = 1:meqn, i = 1-mbc:mx+mbc, j = -1:1, k = 1:2)
+      forall (m = 1:meqn, k = 1:2, j = -1:1, i = 1-mbc:mx+mbc)
           gadd(m, k, j, i) = 0.d0
           hadd(m, k, j, i) = 0.d0
       end forall

--- a/src/fortran/3d/classic/flux3fw.f
+++ b/src/fortran/3d/classic/flux3fw.f
@@ -191,7 +191,7 @@ c
           qadd(m,i) = 0.d0
           fadd(m,i) = 0.d0
       end forall
-      forall (m = 1:meqn, i = 1-mbc:mx+mbc, j = -1:1, k = 1:2)
+      forall (m = 1:meqn, k = 1:2, j = -1:1, i = 1-mbc:mx+mbc)
           gadd(m, k, j, i) = 0.d0
           hadd(m, k, j, i) = 0.d0
       end forall

--- a/src/fortran/3d/classic/step3ds.f
+++ b/src/fortran/3d/classic/step3ds.f
@@ -225,7 +225,9 @@ c
 c        # Since dimensional splitting is used, only aux2 is needed.
 c
          if (maux .gt. 0)  then
-            forall (ma = 1:maux, j = 1-mbc:my+mbc, ia = -1:1)
+            ! There's a decent chance aux2 will all fit into cache,
+            ! so keep accesses to aux as contiguous as possible.
+            forall (ma = 1:maux, ia = -1:1, j = 1-mbc:my+mbc)
                 aux2(ma, j, 2+ia) = aux(ma, i+ia, j, k)
             end forall
          endif
@@ -306,7 +308,9 @@ c
 c        # Since dimensional splitting is used, only aux2 is needed.
 c
          if (maux .gt. 0)  then
-            forall (ma = 1:maux, k = 1-mbc:mz+mbc, ja = -1:1)
+            ! There's a decent chance aux2 will all fit into cache,
+            ! so keep accesses to aux as contiguous as possible.
+            forall (ma = 1:maux, ja = -1:1, k = 1-mbc:mz+mbc)
                 aux2(ma, k, 2+ja) = aux(ma, i, j+ja, k)
             end forall
            endif


### PR DESCRIPTION
I've updated the 3D fortran code to use forall constructs where applicable, and rearranged some do loops where I didn't think I could use a forall.  I get about a 5% performance improvement on my laptop.  (See also the discussion on claw-dev.)  Results from David's acoustics test code are unchanged.
