### PR TITLE
Makefile queries f2py to set FC and FFLAGS

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1,6 +1,6 @@
 classic1.so: $(ONE_D_CLASSIC_SOURCES) $(RP_SOURCE)
 	${F2PY} -m classic1 -c $^
-	
+
 classic1fw.so: $(ONE_D_CLASSIC_FWAVE_SOURCES) $(RP_SOURCE)
 	${F2PY} -m classic1fw -c $^
 
@@ -15,7 +15,7 @@ classic2.so: $(TWO_D_CLASSIC_SOURCES) $(RP_SOURCE)
 
 classic2fw.so: $(TWO_D_CLASSIC_FWAVE_SOURCES) $(RP_SOURCE)
 	${F2PY} -m classic2fw -c $^
-	
+
 sharpclaw2.so: $(TWO_D_SHARPCLAW_SOURCES) $(RP_SOURCE) 
 	${F2PY} -m sharpclaw2 -c $(TWO_D_SHARPCLAW_SOURCES) $(RP_SOURCE) 
 

--- a/Makefile.variables
+++ b/Makefile.variables
@@ -1,6 +1,7 @@
-FC ?= gfortran
-F2PY ?= f2py
-FFLAGS ?=
+F2PY = f2py
+PYTHON = python
+FC := $(shell $(PYTHON) $(PYCLAW)/src/pyclaw/build/fcompiler.py get_compiler)
+FFLAGS := $(shell $(PYTHON) $(PYCLAW)/src/pyclaw/build/fcompiler.py get_flags)
 
 ONE_D_CLASSIC = $(PYCLAW)/src/fortran/1d/classic
 

--- a/src/pyclaw/build/fcompiler.py
+++ b/src/pyclaw/build/fcompiler.py
@@ -1,0 +1,15 @@
+
+def get_fcompiler():
+    import numpy.distutils.fcompiler
+    numpy.distutils.log.set_verbosity(-1)
+    fc = numpy.distutils.fcompiler.new_fcompiler()
+    fc.customize()
+    return fc
+
+if __name__=="__main__":
+    fc = get_fcompiler()
+    import sys
+    if sys.argv[1] == 'get_compiler':
+        print fc.compiler_f77[0]
+    elif sys.argv[1] == 'get_flags':
+        print ' '.join(fc.compiler_f77[1:])


### PR DESCRIPTION
This is a small but non-trivial pull request.  Currently we rely on the user to set FC and FFLAGS as needed.  In this commit, I've modified the Makefiles to directly query f2py using an assist script in src/pyclaw/build.  All nosetests pass on my laptop, but I do not have a very interesting setup.

I'm hoping that at least one Linux user can pull this down and verify that it works on their system, then report results back here.

Thanks!
