### PR TITLE
Fix Riemann solver name for 1d advection with variable coefficient

### DIFF
--- a/apps/advection/1d/variable/Makefile
+++ b/apps/advection/1d/variable/Makefile
@@ -1,6 +1,6 @@
 PYCLAWMAKE = $(PYCLAW)/Makefile.common
 
-RP_SOURCE = $(RIEMANN)/src/rp1adcol.f
+RP_SOURCE = $(RIEMANN)/src/rp1_advection_color.f
 
 all: classic1.so sharpclaw1.so
 


### PR DESCRIPTION
This pull fix issue #105.

The name of the Riemann solver has been updated: rp1_adcol.f  -> rp1_advection_color.f
