### PR TITLE
Make fwave a run-time (not compile-time) option.

### DIFF
--- a/apps/elasticity/1d/stegoton/stegoton.py
+++ b/apps/elasticity/1d/stegoton/stegoton.py
@@ -64,7 +64,7 @@ def moving_wall_bc(grid,dim,t,qbc,mbc):
 
 
 
-def stegoton(use_petsc=1,kernel_language='Fortran',solver_type='classic',iplot=0,htmlplot=0,outdir='./_output'):
+def stegoton(use_petsc=0,kernel_language='Fortran',solver_type='classic',iplot=0,htmlplot=0,outdir='./_output'):
     """
     Stegoton problem.
     Nonlinear elasticity in periodic medium.

--- a/src/fortran/1d/classic/step1fw.f
+++ b/src/fortran/1d/classic/step1fw.f
@@ -1,7 +1,7 @@
 c
 c
 c ===================================================================
-      subroutine step1(maxmx,meqn,mwaves,mbc,maux,mx,q,aux,dx,dt,
+      subroutine step1(meqn,mwaves,mbc,maux,mx,q,aux,dx,dt,
      &              method,mthlim,cfl,f,fwave,s,amdq,apdq,dtdx)
 c ===================================================================
 c     # This version uses interleaved arrays.
@@ -26,34 +26,34 @@ c
 c
 c     amdq, apdq, fwave, s, and f are used locally:
 c
-c     amdq(meqn,1-mbc:maxmx+mbc) = left-going flux-differences
-c     apdq(meqn,1-mbc:maxmx+mbc) = right-going flux-differences
+c     amdq(meqn,1-mbc:mx+mbc) = left-going flux-differences
+c     apdq(meqn,1-mbc:mx+mbc) = right-going flux-differences
 c        e.g. amdq(m,i) = m'th component of A^- \Delta q from i'th Riemann
 c                         problem (between cells i-1 and i).
 c
-c     fwave( meqn, mwaves,1-mbc:maxmx+mbc) = waves from solution of
+c     fwave( meqn, mwaves,1-mbc:mx+mbc) = waves from solution of
 c                                           Riemann problems,
 c            fwave(m,mw,i) = mth component of jump in f across
 c                           wave in family mw in Riemann problem between
 c                           states i-1 and i.
 c
-c     s(1-mbc:maxmx+mbc, mwaves) = wave speeds,
+c     s(1-mbc:mx+mbc, mwaves) = wave speeds,
 c            s(mw,i) = speed of wave in family mw in Riemann problem between
 c                      states i-1 and i.
 c
-c     f(meqn,1-mbc:maxmx+mbc) = correction fluxes for second order method
+c     f(meqn,1-mbc:mx+mbc) = correction fluxes for second order method
 c            f(m,i) = mth component of flux at left edge of ith cell 
 c     --------------------------------------------------------------------
 c
       implicit double precision (a-h,o-z)
-      dimension    q(meqn,1-mbc:maxmx+mbc)
-      dimension  aux(maux,1-mbc:maxmx+mbc)
-      dimension    f(meqn,1-mbc:maxmx+mbc)
-      dimension    s(mwaves,1-mbc:maxmx+mbc)
-      dimension fwave(meqn, mwaves,1-mbc:maxmx+mbc)
-      dimension amdq(meqn,1-mbc:maxmx+mbc)
-      dimension apdq(meqn,1-mbc:maxmx+mbc)
-      dimension dtdx(1-mbc:maxmx+mbc)
+      dimension    q(meqn,1-mbc:mx+mbc)
+      dimension  aux(maux,1-mbc:mx+mbc)
+      dimension    f(meqn,1-mbc:mx+mbc)
+      dimension    s(mwaves,1-mbc:mx+mbc)
+      dimension fwave(meqn, mwaves,1-mbc:mx+mbc)
+      dimension amdq(meqn,1-mbc:mx+mbc)
+      dimension apdq(meqn,1-mbc:mx+mbc)
+      dimension dtdx(1-mbc:mx+mbc)
       dimension method(7),mthlim(mwaves)
       logical limit
 
@@ -62,7 +62,7 @@ cf2py intent(in,out) q
 cf2py intent(out) cfl  
 cf2py intent(in) meqn  
 cf2py intent(in) mbc  
-cf2py intent(in) maxmx  
+cf2py intent(in) mx  
 cf2py optional f, amdq, apdq, dtdx, s, fwave
 
 c
@@ -90,7 +90,7 @@ c
 c     # solve Riemann problem at each interface 
 c     -----------------------------------------
 c
-      call rp1(maxmx,meqn,mwaves,mbc,mx,q,q,aux,aux,fwave,s,amdq,apdq)
+      call rp1(mx,meqn,mwaves,mbc,mx,q,q,aux,aux,fwave,s,amdq,apdq)
 c
 c     # Modify q for Godunov update:
 c     # Note this may not correspond to a conservative flux-differencing
@@ -127,7 +127,7 @@ c
 c
 c     # apply limiter to waves:
       if (limit) then
-         call limiter(maxmx,meqn,mwaves,mbc,mx,fwave,s,mthlim)
+         call limiter(mx,meqn,mwaves,mbc,mx,fwave,s,mthlim)
          endif
 
 c


### PR DESCRIPTION
This fixes issue #108 in clawpack/pyclaw.  It eliminates a lot of duplicated Fortran code as well, by passing solver.fwave in to the fortran routines and then using that to determine which algorithm to use.

We should look at other ways in which we can move control from the Makefiles to the Python code.
