### PR TITLE
Add nested check for single time stepping

### DIFF
--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -633,10 +633,11 @@ class Solver(object):
             state = solution.state
             
             # Adjust dt so that we hit tend exactly if we are near tend
-            if solution.t + self.dt > tend and tstart < tend and not take_one_step:
-                self.dt = tend - solution.t 
-            if tend - solution.t - self.dt < 1.e-14:
-                self.dt = tend - solution.t
+            if not take_one_step:
+                if solution.t + self.dt > tend and tstart < tend:
+                    self.dt = tend - solution.t
+                if tend - solution.t - self.dt < 1.e-14:
+                    self.dt = tend - solution.t
 
             # Keep a backup in case we need to retake a time step
             if self.dt_variable:


### PR DESCRIPTION
This fixes issue #163 which was a bug report for single time stepping output (output style 3).  Turned out that the only thing that needed changing was the nesting of the conditionals at the top of the time loop.  

It may be a good idea to test the second logical statement in the code (line 635-640)

``` python
# Adjust dt so that we hit tend exactly if we are near tend
if not take_one_step:
    if solution.t + self.dt > tend and tstart < tend:
        self.dt = tend - solution.t
    if tend - solution.t - self.dt < 1.e-14:
        self.dt = tend - solution.t
```

is still working as I think it is the one that broke the single time stepping code.
