### PR TITLE
Make the shockbubble example run again.

### DIFF
--- a/src/pyclaw/sharpclaw/sharpclaw.py
+++ b/src/pyclaw/sharpclaw/sharpclaw.py
@@ -162,7 +162,7 @@ class SharpClawSolver(Solver):
  
         if self.kernel_language=='Fortran':
             if self.fmod is None:
-                so_name = 'pyclaw.sharpclaw.sharpclaw'+str(self.num_dim)
+                so_name = 'clawpack.pyclaw.sharpclaw.sharpclaw'+str(self.num_dim)
                 self.fmod = __import__(so_name,fromlist=['pyclaw.sharpclaw'])
             state.set_cparam(self.fmod)
             state.set_cparam(self.rp)


### PR DESCRIPTION
The shockbubble example didn't run when the solver_type was set to 'sharpclaw'.
