### PR TITLE
new feature make deploy in doc/ updates website

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,6 +16,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  deploy     to deploy HTML files to numerics.kaust.edu.sa/pyclaw"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -35,6 +36,14 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)/*
+
+deploy: html
+	@echo
+	@echo "Deploying generated HTML to http://numerics.kaust.edu.sa/pyclaw"
+	@rsync -avz _build/html/* numerics.kaust.edu.sa:/var/www/html/pyclaw
+	@echo "Fixing up remote permissions"
+	@ssh numerics.kaust.edu.sa "chmod -R g+w /var/www/html/pyclaw"
+	@echo "Deployed! check results at: http://numerics.kaust.edu.sa/pyclaw"
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html


### PR DESCRIPTION
Assuming an SSH alias is available, the make deploy command now builds, then rsyncs the documentation over and post-fixes permissions to http://numerics.kaust.edu.sa/pyclaw so that anybody in the team can update the docs.
