### PR TITLE
Issue 209: replace the use of absolute error with relative error in testing homogenous acoustics 2D 

### DIFF
--- a/apps/acoustics_2d_homogeneous/test_2d_acoustics.py
+++ b/apps/acoustics_2d_homogeneous/test_2d_acoustics.py
@@ -16,8 +16,6 @@ def test_2d_acoustics():
                 test_pressure = test_q[0,:,:]
                 thisdir = os.path.dirname(__file__)
                 expected_pressure = np.loadtxt(os.path.join(thisdir,data_filename))
-                test_err = np.linalg.norm(expected_pressure-test_pressure)
-                expected_err = 0
                 return check_diff(expected_pressure, test_pressure, reltol=1e-3)
             else:
                 return


### PR DESCRIPTION
This should close issue #209, I guess
