### PR TITLE
Use indices in testing whether on a boundary

### DIFF
--- a/src/petclaw/geometry.py
+++ b/src/petclaw/geometry.py
@@ -20,6 +20,9 @@ class Patch(pyclaw_geometry.Patch):
             num_cells   = nrange[1]-nrange[0]
             grid_dimensions.append(pyclaw_geometry.Dimension(lower,upper,
                                         num_cells,name=dimensions[i].name))
+            grid_dimensions[-1].lower_index = nrange[0]
+            grid_dimensions[-1].upper_index = nrange[1]
+
 
         self.grid = pyclaw_geometry.Grid(grid_dimensions)
 

--- a/src/pyclaw/geometry.py
+++ b/src/pyclaw/geometry.py
@@ -101,6 +101,16 @@ class Grid(object):
         r"""(list) - Upper coordinate extends of each dimension"""
         return self.get_dim_attribute('upper')
     @property
+    def lower_indices(self):
+        r"""(list) - Lower grid indices of each dimension relative
+                  to the Patch object containing the grid."""
+        return self.get_dim_attribute('lower_index')
+    @property
+    def upper_indices(self):
+        r"""(list) - Upper grid indices of each dimension relative
+                  to the Patch object containing the grid."""
+        return self.get_dim_attribute('upper_index')
+    @property
     def delta(self):
         r"""(list) - List of computational cell widths"""
         return self.get_dim_attribute('delta')
@@ -458,6 +468,12 @@ class Dimension(object):
         r"""(float) - Lower computational dimension extent"""
         self.upper = 1.0
         r"""(float) - Upper computational dimension extent"""
+        self.lower_index = 0
+        r"""(int) - Lower index of the dimension of the containing
+                  Patch or Grid object"""
+        self.upper_index = None
+        r"""(int) - Upper index of the dimension of the containing
+                  Patch or Grid object"""
         self.units = None
         r"""(string) Corresponding physical units of this dimension (e.g. 
         'm/s'), ``default = None``"""
@@ -474,6 +490,8 @@ class Dimension(object):
             self.num_cells = int(args[3])
         else:
             raise Exception("Invalid initializer for Dimension.")
+        
+        self.upper_index = self.num_cells
         
         for (k,v) in kargs.iteritems():
             setattr(self,k,v)
@@ -509,6 +527,14 @@ class Patch(object):
     def upper_global(self):
         r"""(list) - Upper coordinate extends of each dimension"""
         return self.get_dim_attribute('upper')
+    @property
+    def lower_global_indices(self):
+        r"""(list) - Lower patch indices of each dimension"""
+        return self.get_dim_attribute('lower_index')
+    @property
+    def upper_global_indices(self):
+        r"""(list) - Upper patch indices of each dimension"""
+        return self.get_dim_attribute('upper_index')
     @property
     def num_dim(self):
         r"""(int) - Number of dimensions"""

--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -338,13 +338,13 @@ class Solver(object):
         for idim,dim in enumerate(grid.dimensions):
             # First check if we are actually on the boundary
             # (in case of a parallel run)
-            if state.grid.lower[idim] == state.patch.lower_global[idim]:
+            if state.grid.lower_indices[idim] == state.patch.lower_global_indices[idim]:
                 # If a user defined boundary condition is being used, send it on,
                 # otherwise roll the axis to front position and operate on it
                 if self.bc_lower[idim] == BC.custom:
                     self.qbc_lower(state,dim,state.t,self.qbc,idim)
                 elif self.bc_lower[idim] == BC.periodic:
-                    if state.grid.upper[idim] == state.patch.upper_global[idim]:
+                    if state.grid.upper_indices[idim] == state.patch.upper_global_indices[idim]:
                         # This process owns the whole domain
                         self.qbc_lower(state,dim,state.t,np.rollaxis(self.qbc,idim+1,1),idim)
                     else:
@@ -352,11 +352,11 @@ class Solver(object):
                 else:
                     self.qbc_lower(state,dim,state.t,np.rollaxis(self.qbc,idim+1,1),idim)
 
-            if state.grid.upper[idim] == state.patch.upper_global[idim]:
+            if state.grid.upper_indices[idim] == state.patch.upper_global_indices[idim]:
                 if self.bc_upper[idim] == BC.custom:
                     self.qbc_upper(state,dim,state.t,self.qbc,idim)
                 elif self.bc_upper[idim] == BC.periodic:
-                    if state.grid.lower[idim] == state.patch.lower_global[idim]:
+                    if state.grid.lower_indices[idim] == state.patch.lower_global_indices[idim]:
                         # This process owns the whole domain
                         self.qbc_upper(state,dim,state.t,np.rollaxis(self.qbc,idim+1,1),idim)
                     else:
@@ -478,13 +478,13 @@ class Solver(object):
         for idim,dim in enumerate(patch.dimensions):
             # First check if we are actually on the boundary
             # (in case of a parallel run)
-            if state.grid.lower[idim] == state.patch.lower_global[idim]:
+            if state.grid.lower_indices[idim] == state.patch.lower_global_indices[idim]:
                 # If a user defined boundary condition is being used, send it on,
                 # otherwise roll the axis to front position and operate on it
                 if self.aux_bc_lower[idim] == BC.custom:
                     self.auxbc_lower(state,dim,state.t,self.auxbc,idim)
                 elif self.aux_bc_lower[idim] == BC.periodic:
-                    if state.grid.upper[idim] == state.patch.upper_global[idim]:
+                    if state.grid.upper_indices[idim] == state.patch.upper_global_indices[idim]:
                         # This process owns the whole patch
                         self.auxbc_lower(state,dim,state.t,np.rollaxis(self.auxbc,idim+1,1),idim)
                     else:
@@ -492,11 +492,11 @@ class Solver(object):
                 else:
                     self.auxbc_lower(state,dim,state.t,np.rollaxis(self.auxbc,idim+1,1),idim)
 
-            if state.grid.upper[idim] == state.patch.upper_global[idim]:
+            if state.grid.upper_indices[idim] == state.patch.upper_global_indices[idim]:
                 if self.aux_bc_upper[idim] == BC.custom:
                     self.auxbc_upper(state,dim,state.t,self.auxbc,idim)
                 elif self.aux_bc_upper[idim] == BC.periodic:
-                    if state.grid.lower[idim] == state.patch.lower_global[idim]:
+                    if state.grid.lower_indices[idim] == state.patch.lower_global_indices[idim]:
                         # This process owns the whole patch
                         self.auxbc_upper(state,dim,state.t,np.rollaxis(self.auxbc,idim+1,1),idim)
                     else:


### PR DESCRIPTION
This is done to avoid using the upper and lower coordinate extents
in this check as floats equality comparison is not safe.
