### PR TITLE
Fix to make the controller responsible for setting the directory path of gauges

### DIFF
--- a/apps/psystem_2d/test_2d_psystem.py
+++ b/apps/psystem_2d/test_2d_psystem.py
@@ -11,7 +11,6 @@ def test_2d_psystem():
             from clawpack.pyclaw.util import check_diff
 
             gauge_files = test_state.grid.gauge_files
-            gauge_path = test_state.grid.gauge_path
             test_gauge_data= test_state.gauge_data
             expected_gauges=[]
             thisdir = os.path.dirname(__file__)

--- a/src/pyclaw/controller.py
+++ b/src/pyclaw/controller.py
@@ -34,6 +34,19 @@ class Controller(object):
         >>> claw.solution = pyclaw.Solution(state,domain)
         >>> claw.solver = pyclaw.ClawSolver1D()
     """
+
+    #  ======================================================================
+    #   Property Definitions
+    #  ======================================================================
+    @property
+    def outdir_p(self):
+        r"""(string) - Directory to use for writing derived quantity files"""
+        return os.path.join(self.outdir,'_p')
+    @property
+    def F_path(self):
+        r"""(string) - Full path to output file for functionals"""
+        return os.path.join(self.outdir,self.F_file_name+'.txt')
+
     #  ======================================================================
     #   Initialization routines
     #  ======================================================================
@@ -137,16 +150,12 @@ class Controller(object):
         r"""(string) - File prefix to be prepended to derived quantity output files"""
         self.compute_p = None
         r"""(function) - function that computes derived quantities"""
-        self.outdir_p = self.outdir+'/_p'
-        r"""(string) - Directory to use for writing derived quantity files"""
-
+        
         # functionals
         self.compute_F = None
         r"""(function) - Function that computes density of functional F"""
         self.F_file_name = 'F'
         r"""(string) - Name of text file containing functionals"""
-        self.F_path = './_output/'+self.F_file_name+'.txt'
-        r"""(string) - Full path to output file for functionals"""
 
     # ========== Access methods ===============================================
     def __str__(self):        
@@ -208,7 +217,7 @@ class Controller(object):
         """
         
         import numpy as np
-
+        self.solution.patch.grid.setup_gauge_files(self.outdir)
         frame = FrameCounter()
         frame.set_counter(self.start_frame)
         if self.keep_copy:

--- a/src/pyclaw/geometry.py
+++ b/src/pyclaw/geometry.py
@@ -174,11 +174,18 @@ class Grid(object):
         self.mapc2p = default_mapc2p
         r"""(func) - Coordinate mapping function"""
         self.gauges = []
-        r"""(list) - List of gauges"""
-        self.gauge_files     = []
-        r"""(list) - List of files to write gauge values to"""
-        self.gauge_path = './_output/_gauges/'
-        r"""(string) - Full path to output directory for gauges"""
+        r"""(list) - List of gauges' indices to be filled by add_gauges
+        method.
+        """
+        self.gauge_file_names  = []
+        r"""(list) - List of file names to write gauge values to"""
+        self.gauge_files = []
+        r"""(list) - List of file objects to write gauge values to"""
+        self.gauge_dir_name = '_gauges'
+        r"""(string) - Name of the output directory for gauges. If the
+        `Controller` class is used to run the application, this directory by
+        default will be created under the `Controller` `outdir` directory.
+        """
         # Dimension parsing
         if isinstance(dimensions,Dimension):
             dimensions = [dimensions]
@@ -358,15 +365,8 @@ class Grid(object):
         For PetClaw, first check whether each gauge is in the part of the grid
         corresponding to this grid.
 
-        THIS SHOULD BE MOVED TO GRID
         """
-        import os
         from numpy import floor
-        if not os.path.exists(self.gauge_path):
-            try:
-                os.makedirs(self.gauge_path)
-            except OSError:
-                print "gauge directory already exists, ignoring"
         
         for gauge in gauge_coords: 
             # Determine gauge locations in units of mesh spacing
@@ -374,12 +374,29 @@ class Grid(object):
                 # Set indices relative to this grid
                 gauge_index = [int(floor((gauge[n]-self.lower[n])/self.delta[n])) 
                                for n in xrange(self.num_dim)]
-                gauge_path = self.gauge_path+'gauge'+'_'.join(str(coord) for coord in gauge)+'.txt'
-
-                if os.path.isfile(gauge_path): 
-                    os.remove(gauge_path)
+                gauge_file_name = 'gauge'+'_'.join(str(coord) for coord in gauge)+'.txt'
+                self.gauge_file_names.append(gauge_file_name)
                 self.gauges.append(gauge_index)
-                self.gauge_files.append(open(gauge_path,'a'))
+
+    def setup_gauge_files(self,outdir):
+        r"""
+        Creates and opens file objects for gauges
+
+        """
+        import os
+        gauge_path = os.path.join(outdir,self.gauge_dir_name)
+        if not os.path.exists(gauge_path):
+            try:
+                os.makedirs(gauge_path)
+            except OSError:
+                print "gauge directory already exists, ignoring"
+        
+        for gauge in self.gauge_file_names: 
+            gauge_file = os.path.join(gauge_path,gauge)
+            if os.path.isfile(gauge_file): 
+                 os.remove(gauge_file)
+            self.gauge_files.append(open(gauge_file,'a'))
+
 
    
 # ============================================================================

--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -715,6 +715,7 @@ class Solver(object):
             to file.
         """
         import numpy as np
+        import os
         for i,gauge in enumerate(solution.state.grid.gauges):
             if self.num_dim == 1:
                 ix=gauge[0];
@@ -733,8 +734,14 @@ class Solver(object):
                 else:
                     gauge_data.append(np.append(t,p))
             
-            solution.state.grid.gauge_files[i].write(str(t)+' '+' '.join(str(j) for j in p)+'\n')  
-
+            try:
+                solution.state.grid.gauge_files[i].write(str(t)+' '+' '.join(str(j) 
+                                                         for j in p)+'\n')  
+            except:
+                raise Exception("Gauge files are not set up correctly. You should call \
+                       \nthe method `setup_gauge_files` of the Grid class object \
+                       \nbefore any call for `write_gauge_values` from the Solver class.")
+                
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
 The problem was that the grid is created with default gauge_path = ./_output/_gauges. After that
the grid function add_gauges is called by the user to add a list of gauges. This function will also create gauge file objects for each gauge using the default path. The user can then create the controller object and set another outdir directory that won't be reflected in the gauges path.

I tried to solve this issue by:
1- removing the gauge_path property to avoid confusion.
2- splitting the method add_gauges to two methods: add_gauges and
setup_gauges. The former will set the gauges indecies and create a list
of file names (only names). The latter will take outdir as input and create
the gauge_files (actual file objects)
3- Added exception message to the solver method write_gauges to
warn the user that s/he needs to call setup_gauges if the method was
not called
4- The controller run method will call setup_gauges passing its own self.outdir

There are also two related issues:
I made outdir_p and F_path controller variables to be python properties so that they reflect the update in the controller outdir
