### PR TITLE
Read file params

### DIFF
--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -529,9 +529,22 @@ def _info_from_argv(argv=None):
             key, value = s.split('=', 1)
         elif os.path.isfile(os.path.join(os.getcwd(),s)):
             file_name = os.path.join(os.getcwd(),s)
-            farg_strs = json.load(open(file_name))
+            try:
+                farg_strs = json.load(open(file_name))
+            except ValueError as ve:
+                msg= ('ERROR: Unable to parse the file {file_name} '
+                'by `json.load` method. Review json'
+                ' documentation for the correct input format ' 
+                '(http://docs.python.org/2/library/json.html)'
+                )
+                print msg.format(file_name=file_name)
+                raise ve
+
             for key, value in farg_strs.iteritems():
-                if value=='True': value=True
+                if value=='True': value=True # confusion, json.load already
+                                             # accept false and true without
+                                             # quotes and parses them as 
+                                             # boolean
                 if value=='False': value=False
                 kwargs[key] = value
                 


### PR DESCRIPTION
I needed the functionality to pass some parameters of pyclaw application scripts through
a parameter file instead of passing them directly on command line. I needed this when I used
the sumatra tool for experiments reproducibility.

This pull request contains my modification to the pyclaw util function _info_from_argv to enable
reading parameters file that has the format expected by json.load function, something like:
{"outdir" : "./Data",
 "use_petsc" : false,
 "sumatra_label" : null
}

The question is whether you think it will be nice to include this in pyclaw? or it will bring us back
to the idea of parameters files that was used in clawpack..
I'm using this file for the parameters that I would set in command line otherwise 
