### PR TITLE
 #187 fix: Add a check to prevent the user from adding two dimensions with the same name

### DIFF
--- a/apps/euler_2d/shockbubble.py
+++ b/apps/euler_2d/shockbubble.py
@@ -182,7 +182,7 @@ def shockbubble(use_petsc=False,kernel_language='Fortran',solver_type='classic',
     # Initialize domain
     mx=160; my=40
     x = pyclaw.Dimension('x',0.0,2.0,mx)
-    y = pyclaw.Dimension('x',0.0,0.5,my)
+    y = pyclaw.Dimension('y',0.0,0.5,my)
     domain = pyclaw.Domain([x,y])
     num_eqn = 5
     num_aux=1


### PR DESCRIPTION
This is suggested fix for issue #187.

I have a question here,,, there are two error messages with the same content,
what do you think is the best practice for such case. I thought of creating exception class
for that but I'm not sure if this is the right way to go

```
class DimensionNameError(Exception):
    def __str__(self):
        return "the specific message that could include args"
```
