### PR TITLE
Adding LAPACK dependency to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - 2.7
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq gfortran
+  - sudo apt-get install -qq gfortran liblapack-pic
   # Print NumPy version that is already installed by Travis CI:
   - python -c "import numpy; print numpy.__version__"
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack


### PR DESCRIPTION
This installs LAPACK before starting the installation (which depends on LAPACK).
