### PR TITLE
docstring inheritance

### DIFF
--- a/src/petclaw/cfl.py
+++ b/src/petclaw/cfl.py
@@ -1,8 +1,11 @@
 r"""
-Module for the CFL object, which is responsible for computing and enforcing the
-Courant-Friedrichs-Lewy condition.
+Module for the CFL object.
 """
 class CFL(object):
+    """ Parallel CFL object, responsible for computing the
+    Courant-Friedrichs-Lewy condition across all processes.
+    """
+
     def __init__(self, global_max):
         from petsc4py import PETSc
         self._local_max = global_max

--- a/src/petclaw/classic/solver.py
+++ b/src/petclaw/classic/solver.py
@@ -7,29 +7,25 @@ determine the containing claw_package to use.
 """
 
 from __future__ import absolute_import
-from clawpack.pyclaw.classic import solver
+from clawpack import pyclaw
 
-class ClawSolver1D(solver.ClawSolver1D):
+class ClawSolver1D(pyclaw.ClawSolver1D):
     r"""
-    PetClaw solver for 1D problems using classic Clawpack algorithms.
-
-    This class implements nothing; it just inherits from ClawSolver1D.
+    Parallel solver for 1D problems using classic Clawpack algorithms.
     """
 
-class ClawSolver2D(solver.ClawSolver2D):
-    r"""
-    PetClaw solver for 2D problems using classic Clawpack algorithms.
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw.ClawSolver1D)
 
-    This class implements nothing; it just inherits from ClawSolver2D.
-    
-    Note that only the fortran routines are supported for now in 2D.
-    """
-    
-class ClawSolver3D(solver.ClawSolver3D):
+class ClawSolver2D(pyclaw.ClawSolver2D):
     r"""
-    PetClaw solver for 3D problems using classic Clawpack algorithms.
-
-    This class implements nothing; it just inherits from ClawSolver3D.
-    
-    Note that only fortran routines are supported in 3D.
+    Parallel solver for 2D problems using classic Clawpack algorithms.
     """
+
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw.ClawSolver2D)
+    
+class ClawSolver3D(pyclaw.ClawSolver3D):
+    r"""
+    Parallel solver for 3D problems using classic Clawpack algorithms.
+    """
+
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw.ClawSolver3D)

--- a/src/petclaw/controller.py
+++ b/src/petclaw/controller.py
@@ -1,11 +1,18 @@
 """
-Module for PetClaw controller class.  The PetClaw controller is identical to the
-PyClaw controller except for the default value of output_format.
+Module for PetClaw controller class.
 """
 
-from clawpack.pyclaw.controller import Controller as pyclawController
+import pyclaw
+from clawpack import pyclaw
 
-class Controller(pyclawController):
+class Controller(pyclaw.controller.Controller):
+    """ Parallel Controller Class
+
+    Defaults to petsc output_format, logs only from process 0.
+    """
+    
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw.controller.Controller)
+
     def __init__(self):
         super(Controller,self).__init__()
 

--- a/src/petclaw/geometry.py
+++ b/src/petclaw/geometry.py
@@ -4,9 +4,15 @@ r"""
 Module containing petclaw.geometry.
 """
 
+from clawpack import pyclaw
 from clawpack.pyclaw import geometry as pyclaw_geometry
 
 class Patch(pyclaw_geometry.Patch):
+    """Parallel Patch class.
+    """
+
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw_geometry.Patch)
+    
     def __init__(self,dimensions):
         
         super(Patch,self).__init__(dimensions)
@@ -71,11 +77,11 @@ class Patch(pyclaw_geometry.Patch):
 #  PetClaw Domain object definition
 # ============================================================================
 class Domain(pyclaw_geometry.Domain):
-    r"""
-    A Domain is a list of Patches.
-    
-    Need to add functionality to accept a list of patches as input.
+    r""" Parallel Domain Class    
     """
+    
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw.ClawSolver2D)
+
     def __init__(self,geom):
         if not isinstance(geom,list):
             geom = [geom]

--- a/src/petclaw/sharpclaw/solver.py
+++ b/src/petclaw/sharpclaw/solver.py
@@ -5,14 +5,17 @@ Module containing SharpClaw solvers for PetClaw
 """
 
 from __future__ import absolute_import
-from clawpack.pyclaw.sharpclaw import solver
+from clawpack import pyclaw
 
-class SharpClawSolver1D(solver.SharpClawSolver1D):
-    """
-    1D parallel SharpClaw solver.  See the corresponding PyClaw class for documentation.
+class SharpClawSolver1D(pyclaw.SharpClawSolver1D):
+    """1D parallel SharpClaw solver.
     """
 
-class SharpClawSolver2D(solver.SharpClawSolver2D):
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw.SharpClawSolver2D)
+
+    
+class SharpClawSolver2D(pyclaw.SharpClawSolver2D):
+    """2D parallel SharpClaw solver. 
     """
-    2D parallel SharpClaw solver.  See the corresponding PyClaw class for documentation.
-    """
+
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw.SharpClawSolver2D)

--- a/src/petclaw/solution.py
+++ b/src/petclaw/solution.py
@@ -1,4 +1,7 @@
+from clawpack import pyclaw
 from clawpack.pyclaw.solution import Solution
 
 class Solution(Solution):
-    "Dummy class"
+    """ Parallel Solution class.
+    """
+    __doc__ += pyclaw.util.add_parent_doc(pyclaw.Solution)

--- a/src/petclaw/state.py
+++ b/src/petclaw/state.py
@@ -1,7 +1,9 @@
 import clawpack.pyclaw
 
 class State(clawpack.pyclaw.State):
-    r"""  See the corresponding PyClaw class documentation."""
+    """Parallel State class"""
+
+    __doc__ += clawpack.pyclaw.util.add_parent_doc(clawpack.pyclaw.state)
 
     @property
     def num_eqn(self):

--- a/src/pyclaw/classic/solver.py
+++ b/src/pyclaw/classic/solver.py
@@ -8,9 +8,9 @@ are both pure virtual classes; the only solver classes that should be instantiat
 are the dimension-specific ones, :class:`ClawSolver1D` and :class:`ClawSolver2D`.
 """
 
-from ..solver import Solver
-
-from ..limiters import tvd
+from clawpack.pyclaw.util import add_parent_doc
+from clawpack.pyclaw.solver import Solver
+from clawpack.pyclaw.limiters import tvd
 
 # ============================================================================
 #  Generic Clawpack solver class
@@ -71,13 +71,15 @@ class ClawSolver(Solver):
         The level of detail of logged messages from the Fortran solver.
         ``Default = 0``.
 
-    Output:
-     - (:class:`ClawSolver`) - Initialized clawpack solver
     """
+    
     # ========== Generic Init Routine ========================================
     def __init__(self,riemann_solver=None,claw_package=None):
         r"""
         See :class:`ClawSolver` for full documentation.
+
+        Output:
+        - (:class:`ClawSolver`) - Initialized clawpack solver
         """
         self.num_ghost = 2
         self.limiters = tvd.minmod
@@ -260,13 +262,16 @@ class ClawSolver1D(ClawSolver):
     dependent on the argument given to the initialization of the solver 
     (defaults to python).
     
-    Output:
-     - (:class:`ClawSolver1D`) - Initialized 1d clawpack solver
     """
+
+    __doc__ += add_parent_doc(ClawSolver)
 
     def __init__(self, riemann_solver=None, claw_package=None):
         r"""
         Create 1d Clawpack solver
+
+        Output:
+        - (:class:`ClawSolver1D`) - Initialized 1d clawpack solver
         
         See :class:`ClawSolver1D` for more info.
         """   
@@ -399,7 +404,6 @@ class ClawSolver2D(ClawSolver):
     Solve using the wave propagation algorithms of Randy LeVeque's
     Clawpack code (www.clawpack.org).
 
-    See also the documentation for ClawSolver1D.
     In addition to the attributes of ClawSolver1D, ClawSolver2D
     also has the following options:
     
@@ -429,6 +433,8 @@ class ClawSolver2D(ClawSolver):
     Note that only the fortran routines are supported for now in 2D.
     """
 
+    __doc__ += add_parent_doc(ClawSolver)
+    
     no_trans  = 0
     trans_inc = 1
     trans_cor = 2
@@ -556,8 +562,7 @@ class ClawSolver3D(ClawSolver):
     Solve using the wave propagation algorithms of Randy LeVeque's
     Clawpack code (www.clawpack.org).
 
-    See also the documentation for ClawSolver1D.
-    In addition to the attributes of ClawSolver1D, ClawSolver3D
+    In addition to the attributes of ClawSolver, ClawSolver3D
     also has the following options:
     
     .. attribute:: dimensional_split
@@ -586,6 +591,8 @@ class ClawSolver3D(ClawSolver):
     Note that only Fortran routines are supported for now in 3D --
     there is no pure-python version.
     """
+
+    __doc__ += add_parent_doc(ClawSolver)
 
     no_trans  = 0
     trans_inc = 11

--- a/src/pyclaw/sharpclaw/solver.py
+++ b/src/pyclaw/sharpclaw/solver.py
@@ -6,16 +6,16 @@ Module containing SharpClaw solvers for PyClaw/PetClaw
 #  Author:      David Ketcheson
 """
 # Solver superclass
-from ..solver import Solver, CFLError
+from clawpack.pyclaw.solver import Solver, CFLError
+from clawpack.pyclaw.util import add_parent_doc
 
 # Reconstructor
 try:
     # load c-based WENO reconstructor (PyWENO)
-    from ..limiters import reconstruct as recon
+    from clawpack.pyclaw.limiters import reconstruct as recon
 except ImportError:
     # load old WENO5 reconstructor
-    from ..limiters import recon
-
+    from clawpack.pyclaw.limiters import recon
 
 def before_step(solver,solution):
     r"""
@@ -366,6 +366,9 @@ class SharpClawSolver1D(SharpClawSolver):
     Used to solve 1D hyperbolic systems using the SharpClaw algorithms,
     which are based on WENO reconstruction and Runge-Kutta time stepping.
     """
+
+    __doc__ += add_parent_doc(SharpClawSolver)
+    
     def __init__(self,riemann_solver=None,claw_package=None):
         r"""
         See :class:`SharpClawSolver1D` for more info.
@@ -504,11 +507,11 @@ class SharpClawSolver1D(SharpClawSolver):
 # ========================================================================
 class SharpClawSolver2D(SharpClawSolver):
 # ========================================================================
-    """SharpClaw evolution routine in 2D
-    
-    This class represents the 2D SharpClaw solver.  Note that there are 
-    routines here for interfacing with the fortran time stepping routines only.
+    """ Two Dimensional SharpClawSolver
     """
+
+    __doc__ += add_parent_doc(SharpClawSolver)
+
     def __init__(self,riemann_solver=None,claw_package=None):
         r"""
         Create 2D SharpClaw solver

--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -11,6 +11,15 @@ import logging
 import tempfile
 import numpy as np
 
+def add_parent_doc(parent):
+    """add parent documentation for a class""" 
+    
+    return """
+    Parent Class Documentation
+    ==========================
+    """ + parent.__doc__
+
+
 def run_app_from_main(application):
     r"""
     Runs an application from apps/, automatically parsing command line keyword


### PR DESCRIPTION
Docstring inheritance, so that statements like:

```
In [1]: import clawpack.petclaw
In [2]: clawpack.petclaw.SharpClawSolver1D?
```

return 

```
Type:       type
String Form:<class 'clawpack.petclaw.sharpclaw.solver.SharpClawSolver1D'>
File:       /Users/aron/sandbox/clawpack/clawpack/petclaw/sharpclaw/solver.py
Docstring:
1D parallel SharpClaw solver.

Parent Class Documentation
==========================
 Two Dimensional SharpClawSolver

Parent Class Documentation
==========================

Superclass for all SharpClawND solvers.

Implements Runge-Kutta time stepping and the basic form of a
semi-discrete step (the dq() function).  If another method-of-lines
solver is implemented in the future, it should be based on this class,
which then ought to be renamed to something like "MOLSolver".

...
```
