### PR TITLE
write initial aux if write_aux_always is set.

### DIFF
--- a/src/pyclaw/controller.py
+++ b/src/pyclaw/controller.py
@@ -266,10 +266,11 @@ class Controller(object):
                                         options = self.output_options,
                                         write_p = True) 
 
+            write_aux = (write_aux_always or write_aux_init)
             self.solution.write(frame,self.outdir,
                                         self.output_format,
                                         self.output_file_prefix,
-                                        self.write_aux_init,
+                                        write_aux,
                                         self.output_options)
 
         self.write_F('w')


### PR DESCRIPTION
Fixes an issue pointed out by @mandli here: https://github.com/clawpack/pyclaw/pull/228#issuecomment-22080136.
