### PR TITLE
fixed issue for take_one_step

### DIFF
--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -691,7 +691,7 @@ class Solver(object):
                     self.dt = self.dt_max
 
             # See if we are finished yet
-            if solution.t >= tend or take_one_step:
+            if (solution.t >= tend and not take_one_step) or (take_one_step and solution.t > tstart):
                 break
       
         # End of main time-stepping loop -------------------------------------


### PR DESCRIPTION
This fixes an issue when using PyClaw with PeanoClaw. Since PeanoClaw always computes a single timestep, take_one_step is true in evolve_to_time. When the initial dt was too large, no timesteps where taken at all.

The fix leaves the functionality untouched when running evolve_to_time to take several timesteps (as usually done), but fixes the issue for taking a single timestep.

nosetest provides the same results as without the fix.

Regards,
Kristof
