### PR TITLE
Do a relative and absolute comparison for aux descriptor variables

### DIFF
--- a/src/pyclaw/io/ascii.py
+++ b/src/pyclaw/io/ascii.py
@@ -277,8 +277,8 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
 
     # Read auxillary file if available and requested
     # Matching dimension parameter tolerances
-    abs_tol = 1e-8
-    rel_tol = 1e-15
+    ABS_TOL = 1e-8
+    REL_TOL = 1e-15
     if solution.states[0].num_aux > 0 and read_aux:
         # Check for aux file
         fname1 = os.path.join(base_path,'%s.a' % file_prefix)+str(frame).zfill(4)
@@ -318,11 +318,11 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
                     raise Exception("Dimension %s's num_cells in aux file header did not match patch no %s." % (dim.name,patch.patch_index))
             for dim in patch.dimensions:
                 lower = read_data_line(f,type='float')
-                if np.abs(lower - dim.lower) <= abs_tol + rel_tol * np.abs(dim.lower):
+                if np.abs(lower - dim.lower) > ABS_TOL + REL_TOL * np.abs(dim.lower):
                     raise Exception('Value of lower in aux file does not match.')
             for dim in patch.dimensions:
                 delta = read_data_line(f,type='float')
-                if np.abs(delta - dim.delta) <= abs_tol + rel_tol * np.abs(dim.delta):
+                if np.abs(delta - dim.delta) > ABS_TOL + REL_TOL * np.abs(dim.delta):
                     raise Exception('Value of delta in aux file does not match.')
 
             f.readline()


### PR DESCRIPTION
This PR addresses #327 where sometimes the descriptor output precision could lead to erroneous comparison errors.  The alternative to doing this would be to write out a higher precision value for all descriptors.
