### PR TITLE
Better interactive behavior of controller.

### DIFF
--- a/src/pyclaw/classic/solver.py
+++ b/src/pyclaw/classic/solver.py
@@ -223,7 +223,7 @@ class ClawSolver(Solver):
 
         self._allocate_bc_arrays(solution.states[0])
 
-        self._is_set_up = True
+        super(ClawSolver,self).setup(solution)
 
 
     def _set_fortran_parameters(self,solution):
@@ -240,13 +240,14 @@ class ClawSolver(Solver):
         solution.state.set_cparam(self.fmod)
         solution.state.set_cparam(self.rp)
 
-    def teardown(self):
+    def __del__(self):
         r"""
         Delete Fortran objects, which otherwise tend to persist in Python sessions.
         """
         if(self.kernel_language == 'Fortran'):
             del self.fmod
 
+        super(ClawSolver,self).__del__()
 
 
 # ============================================================================

--- a/src/pyclaw/sharpclaw/solver.py
+++ b/src/pyclaw/sharpclaw/solver.py
@@ -183,7 +183,22 @@ class SharpClawSolver(Solver):
 
         self._allocate_bc_arrays(state)
 
-        self._is_set_up = True
+        super(SharpClawSolver,self).setup(solution)
+
+
+    def __del__(self):
+        r"""
+        Deallocate F90 module arrays.
+        Also delete Fortran objects, which otherwise tend to persist in Python sessions.
+        """
+        if self.kernel_language=='Fortran':
+            self.fmod.clawparams.dealloc_clawparams()
+            self.fmod.workspace.dealloc_workspace(self.char_decomp)
+            self.fmod.reconstruct.dealloc_recon_workspace(self.fmod.clawparams.lim_type,self.fmod.clawparams.char_decomp)
+            del self.fmod
+
+        super(SharpClawSolver,self).__del__()
+
 
     # ========== Time stepping routines ======================================
     def step(self,solution):
@@ -397,18 +412,6 @@ class SharpClawSolver1D(SharpClawSolver):
         super(SharpClawSolver1D,self).__init__(riemann_solver,claw_package)
 
 
-    def teardown(self):
-        r"""
-        Deallocate F90 module arrays.
-        Also delete Fortran objects, which otherwise tend to persist in Python sessions.
-        """
-        if self.kernel_language=='Fortran':
-            self.fmod.clawparams.dealloc_clawparams()
-            self.fmod.workspace.dealloc_workspace(self.char_decomp)
-            self.fmod.reconstruct.dealloc_recon_workspace(self.fmod.clawparams.lim_type,self.fmod.clawparams.char_decomp)
-            del self.fmod
-
-
     def dq_hyperbolic(self,state):
         r"""
         Compute dq/dt * (delta t) for the hyperbolic hyperbolic system.
@@ -541,18 +544,6 @@ class SharpClawSolver2D(SharpClawSolver):
         self.num_dim = 2
 
         super(SharpClawSolver2D,self).__init__(riemann_solver,claw_package)
-
-
-    def teardown(self):
-        r"""
-        Deallocate F90 module arrays.
-        Also delete Fortran objects, which otherwise tend to persist in Python sessions.
-        """
-        if self.kernel_language=='Fortran':
-            self.fmod.workspace.dealloc_workspace(self.char_decomp)
-            self.fmod.reconstruct.dealloc_recon_workspace(self.fmod.clawparams.lim_type,self.fmod.clawparams.char_decomp)
-            self.fmod.clawparams.dealloc_clawparams()
-            del self.fmod
 
 
     def dq_hyperbolic(self,state):

--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -259,9 +259,9 @@ class Solver(object):
         requires knowledge of the solution object.
         """
 
-        pass
+        self._is_set_up = True
 
-    def teardown(self):
+    def __del__(self):
         r"""
         Stub for solver teardown routines.
         
@@ -269,7 +269,8 @@ class Solver(object):
         A subclass should override it only if it needs to 
         perform some cleanup, such as deallocating arrays in a Fortran module.
         """
-        pass
+        self._is_set_up = False
+
 
 
     def __str__(self):


### PR DESCRIPTION
- Tear down solver when solver is deleted, not
  necessarily at end of controller.run()
- Use Python's `__del__()` method to tear down solver
- Don't overwrite old frames if controller.run() is called twice.

This allows for interactive things like:

```
(set controller up)
claw.tfinal = 1
claw.run()
(get some output frames)
claw.tfinal = 2
claw.run()
(more output frames get appended)
```
