### PR TITLE
Ignore symlink to examples directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ pyclaw.log
 .noseids
 _build
 build
+
+# symlink to examples directory
+src/pyclaw/examples


### PR DESCRIPTION
Developers will usually have this symlink present, but it should be ignored by git.
