### PR TITLE
Don't fail if the Riemann solver is not in static.py

### DIFF
--- a/src/pyclaw/controller.py
+++ b/src/pyclaw/controller.py
@@ -203,15 +203,16 @@ class Controller(object):
     def check_validity(self):
         r"""Check that the controller has been properly set up and is ready to run.
 
-            Checks validity of the solver
+            Also checks validity of the solver, solution and states.
         """
         # Check to make sure we have a valid solver to use
         if self.solver is None:
             raise Exception("No solver set in controller.")
         if not isinstance(self.solver,Solver):
             raise Exception("Solver is not of correct type.")
-        if not self.solver.is_valid():
-            raise Exception("The solver failed to initialize properly.") 
+        valid, reason = self.solver.is_valid()
+        if not valid:
+            raise Exception("The solver failed to initialize properly because "+reason) 
             
         # Check to make sure the initial solution is valid
         if not self.solution.is_valid():


### PR DESCRIPTION
This resolves #374.  Also, this provides better error messages when a solver is not valid.  If we decide this is a good approach, the same thing could be done for the functions that check validity of controller, state, and solution.
