### PR TITLE
General update to logging.

### DIFF
--- a/src/pyclaw/controller.py
+++ b/src/pyclaw/controller.py
@@ -17,6 +17,7 @@ import copy
 
 from .solver import Solver
 from .util import FrameCounter
+from .util import LOGGING_LEVELS
 
 class Controller(object):
     r"""Controller for pyclaw simulation runs and plotting
@@ -59,6 +60,16 @@ class Controller(object):
     #  ======================================================================
     #   Property Definitions
     #  ======================================================================
+    @property
+    def verbosity(self):
+        return self._verbosity
+
+    @verbosity.setter
+    def verbosity(self, value):
+        self._verbosity = value
+        # Only adjust console logger; leave file logger alone
+        self.logger.handlers[1].setLevel(LOGGING_LEVELS[value])
+
     @property
     def outdir_p(self):
         r"""(string) - Directory to use for writing derived quantity files"""
@@ -144,13 +155,15 @@ class Controller(object):
         r"""(dict) - Output options passed to function writing and reading 
         data in output_format's format.  ``default = {}``"""
         
+        self.logger = logging.getLogger('pyclaw.controller')
+
         # Classic output parameters, used in run convenience method
         self.tfinal = 1.0
         r"""(float) - Final time output, ``default = 1.0``"""
         self.output_style = 1
         r"""(int) - Time output style, ``default = 1``"""
-        self.verbosity = 0 
-        r"""(int) - Level of output, ``default = 0``"""
+        self.verbosity = 3
+        r"""(int) - Level of output to screen; ``default = 3``"""
         self.num_output_times = 10                  # Outstyle 1 defaults
         r"""(int) - Number of output times, only used with ``output_style = 1``,
         ``default = 10``"""
@@ -399,8 +412,7 @@ class Controller(object):
         return True
 
     def log_info(self, str):
-        import logging
-        logging.info(str)
+        self.logger.info(str)
 
 if __name__ == "__main__":
     import doctest

--- a/src/pyclaw/io/__init__.py
+++ b/src/pyclaw/io/__init__.py
@@ -9,6 +9,7 @@
 """Output package for Pyclaw"""
 
 import logging
+logger = logging.getLogger('pyclaw.io')
 
 import ascii 
 __all__ = ['ascii.read','ascii.write']
@@ -22,7 +23,7 @@ try:
     import hdf5
     __all__ += ['hdf5.read','hdf5.write']
 except ImportError:
-    logging.debug("No hdf5 support found.")
+    logger.debug("No hdf5 support found.")
     
 # Check for netcdf support
 try:
@@ -30,4 +31,4 @@ try:
     import netcdf
     __all__ += ['netcdf.read','netcdf.write']
 except(ImportError):
-    logging.debug("No netcdf4 support found.")
+    logger.debug("No netcdf4 support found.")

--- a/src/pyclaw/io/binary.py
+++ b/src/pyclaw/io/binary.py
@@ -14,7 +14,7 @@ from ..util import read_data_line
 import numpy as np
 import clawpack.pyclaw as pyclaw
 
-logger = logging.getLogger('io')
+logger = logging.getLogger('pyclaw.io')
 
 
 def read(solution,frame,path='./',file_prefix='fort',read_aux=False,

--- a/src/pyclaw/io/hdf5.py
+++ b/src/pyclaw/io/hdf5.py
@@ -30,7 +30,7 @@ import logging
 
 import clawpack.pyclaw.solution
 
-logger = logging.getLogger('io')
+logger = logging.getLogger('pyclaw.io')
 
 # Import appropriate hdf5 package
 use_h5py = False

--- a/src/pyclaw/io/netcdf.py
+++ b/src/pyclaw/io/netcdf.py
@@ -33,7 +33,7 @@ import logging
 
 import clawpack.pyclaw.solution
 
-logger = logging.getLogger('io')
+logger = logging.getLogger('pyclaw.io')
 
 # Import appropriate netcdf package
 use_netcdf4 = False

--- a/src/pyclaw/log.config
+++ b/src/pyclaw/log.config
@@ -7,7 +7,7 @@
 
 # These are the names of the different loggers
 [loggers] 
-keys=root,io,evolve,f2py,data
+keys=root,pyclaw,controller,io,solver,f2py,data
 
 # These are the names of the different handlers that we will setup later
 [handlers]
@@ -23,23 +23,45 @@ keys=default,detailed
 #
 [logger_root]
 level=INFO                             
+qualname=root
 handlers=file,console
 
-[logger_io]
+[logger_pyclaw]
 level=INFO
+qualname=pyclaw
+handlers=file,console
+
+[logger_controller]
+level=NOTSET
 propagate=0
-qualname=io
+qualname=pyclaw.controller
+handlers=file,console
+channel=controller
+parent=(pyclaw)
+
+[logger_io]
+level=NOTSET
+propagate=0
+qualname=pyclaw.io
 handlers=file
 channel=io
-parent=(root)
+parent=(pyclaw)
 
 [logger_solution]
-level=INFO
+level=NOTSET
 propagate=0
-qualname=solution
+qualname=pyclaw.solution
 handlers=file
 channel=solution
-partent=(root)
+partent=(pyclaw)
+
+[logger_solver]
+level=NOTSET
+propagate=0
+qualname=pyclaw.solver
+handlers=file,console
+channel=solver
+parent=(pyclaw)
 
 [logger_plot]
 level=INFO
@@ -47,14 +69,6 @@ propagate=0
 qualname=plot
 handlers=file
 channel=plot
-parent=(root)
-
-[logger_evolve]
-level=INFO
-propagate=0
-qualname=evolve
-handlers=file,console
-channel=evolve
 parent=(root)
 
 [logger_f2py]

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -301,7 +301,7 @@ class Solution(object):
                                 write_aux=write_aux,options=options,
                            write_p=write_p)
             msg = "Wrote out solution in format %s for time t=%s" % (form,self.t)
-            logging.getLogger('io').info(msg)
+            logging.getLogger('pyclaw.io').info(msg)
 
         
     def read(self,frame,path='./_output',file_format='ascii',file_prefix=None,
@@ -352,7 +352,7 @@ class Solution(object):
         else:
             read_func(self,frame,path,file_prefix=file_prefix,
                                     read_aux=read_aux,options=options)
-        logging.getLogger('io').info("Read in solution for time t=%s" % self.t)
+        logging.getLogger('pyclaw.io').info("Read in solution for time t=%s" % self.t)
         
         
     def plot(self):

--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -149,7 +149,7 @@ class Solver(object):
         See :class:`Solver` for full documentation
         """ 
         # Setup solve logger
-        self.logger = logging.getLogger('evolve')
+        self.logger = logging.getLogger('pyclaw.solver')
 
         self.dt_initial = 0.1
         self.dt_max = 1e99

--- a/src/pyclaw/state.py
+++ b/src/pyclaw/state.py
@@ -171,7 +171,7 @@ class State(object):
         """
         import logging
         valid = True
-        logger = logging.getLogger('solution')
+        logger = logging.getLogger('pyclaw.solution')
         if not self.q.flags['F_CONTIGUOUS']:
             logger.debug('q array is not Fortran contiguous.')
             valid = False

--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -11,6 +11,13 @@ import logging
 import tempfile
 import numpy as np
 
+
+LOGGING_LEVELS = {0:logging.CRITICAL,
+                  1:logging.ERROR,
+                  2:logging.WARNING,
+                  3:logging.INFO,
+                  4:logging.DEBUG}
+
 def add_parent_doc(parent):
     """add parent documentation for a class""" 
     


### PR DESCRIPTION
Make all loggers inherit from pyclaw logger.
Add convenience function for setting console logging level in controller (h/t @ahmadia).

I see two main use cases where one wants to adjust the logging:
1. Turn off logging to stdout (IPython notebooks)
2. Turn off all logging (or set all to CRITICAL) (Shaheen)

For 1, we want to selectively modify the level of the console handler for the controller logger.  This can now be done via

```
claw.verbosity = 0
```

Meanwhile, the controller will still write to the log file.

For case 2, one can do 

```
import logging
logger = logging.getLogger('pyclaw')
logger.setLevel(logging.CRITICAL)
```

which propagates to the other loggers.

For completeness, the logger name changes are:

io -> pyclaw.io
solution -> pyclaw.solution
evolve -> pyclaw.solver

and there is a new logger `pyclaw.controller`.
