### PR TITLE
Always create attribute solver.num_eqn.

### DIFF
--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -200,6 +200,9 @@ class Solver(object):
         self.user_aux_bc_lower = None
         self.user_aux_bc_upper = None
 
+        self.num_eqn   = None
+        self.num_waves = None
+
         self.compute_gauge_values = default_compute_gauge_values
         r"""(function) - Function that computes quantities to be recorded at gauges"""
 


### PR DESCRIPTION
This fixes a bug introduced recently, in which the solver did not have attributes 'num_eqn' and 'num_waves' unless it was initialized with a specified Riemann solver.  This is problematic because we don't allow creation of additional solver attributes outside of **init**.  Now these attributes are always created, and set to None if the Riemann solver has not been specified.
