### PR TITLE
Move logic of which pyclaw to import (pyclaw vs petclaw) to run_app_from_main.

### DIFF
--- a/development/rp_approaches/shockbubble.py
+++ b/development/rp_approaches/shockbubble.py
@@ -155,16 +155,14 @@ def step_Euler_radial(solver,state,dt):
     q[3,:,:] = q[3,:,:] - dt*(ndim-1)/rad * v * (qstar[3,:,:] + press)
 
 
-def shockbubble(use_petsc=False,iplot=False,htmlplot=False,outdir='./_output',solver_type='classic'):
+def shockbubble(state_backend='pyclaw',iplot=False,htmlplot=False,outdir='./_output',solver_type='classic'):
     """
     Solve the Euler equations of compressible fluid dynamics.
     This example involves a bubble of dense gas that is impacted by a shock.
     """
 
-    if use_petsc:
-        import petclaw as pyclaw
-    else:
-        import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='sharpclaw':
         solver = pyclaw.SharpClawSolver2D()

--- a/examples/acoustics_1d_homogeneous/acoustics_1d.py
+++ b/examples/acoustics_1d_homogeneous/acoustics_1d.py
@@ -19,16 +19,16 @@ The final solution is identical to the initial data because both waves have
 crossed the domain exactly once.
 """
 
-def setup(state_backend='numpy',kernel_language='Fortran',solver_type='classic',outdir='./_output',weno_order=5,
-        time_integrator='SSP104', disable_output=False, **kwargs):
+def setup(state_backend='pyclaw',kernel_language='Fortran',solver_type='classic',outdir='./_output',weno_order=5,
+        time_integrator='SSP104', disable_output=False):
     """
     This example solves the 1-dimensional acoustics equations in a homogeneous
     medium.
     """
     from numpy import sqrt, exp, cos
     from clawpack import riemann
-    from clawpack.pyclaw.util import get_state_backend
 
+    from clawpack.pyclaw.util import get_state_backend
     pyclaw = get_state_backend(state_backend)
 
     #========================================================================

--- a/examples/acoustics_2d_homogeneous/acoustics_2d.py
+++ b/examples/acoustics_2d_homogeneous/acoustics_2d.py
@@ -6,27 +6,25 @@ Two-dimensional acoustics
 
 Solve the (linear) acoustics equations:
 
-.. math:: 
-    p_t + K (u_x + v_y) & = 0 \\ 
+.. math::
+    p_t + K (u_x + v_y) & = 0 \\
     u_t + p_x / \rho & = 0 \\
     v_t + p_y / \rho & = 0.
 
 Here p is the pressure, (u,v) is the velocity, K is the bulk modulus,
 and :math:`\rho` is the density.
 """
- 
+
 import numpy as np
 
-def setup(kernel_language='Fortran',use_petsc=False,outdir='./_output',solver_type='classic',
+def setup(state_backend='pyclaw',kernel_language='Fortran',outdir='./_output',solver_type='classic',
         time_integrator='SSP104', disable_output=False):
     """
     Example python script for solving the 2d acoustics equations.
     """
     from clawpack import riemann
-    if use_petsc:
-        from clawpack import petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='classic':
         solver=pyclaw.ClawSolver2D(riemann.acoustics_2D)

--- a/examples/acoustics_2d_variable/acoustics_2d_interface.py
+++ b/examples/acoustics_2d_variable/acoustics_2d_interface.py
@@ -6,28 +6,25 @@ Two-dimensional variable-coefficient acoustics
 
 Solve the variable-coefficient acoustics equations:
 
-.. math:: 
-    p_t + K(x,y) (u_x + v_y) & = 0 \\ 
+.. math::
+    p_t + K(x,y) (u_x + v_y) & = 0 \\
     u_t + p_x / \rho(x,y) & = 0 \\
     v_t + p_y / \rho(x,y) & = 0.
 
 Here p is the pressure, (u,v) is the velocity, :math:`K(x,y)` is the bulk modulus,
 and :math:`\rho(x,y)` is the density.
 """
- 
+
 import numpy as np
 
-def setup(kernel_language='Fortran',use_petsc=False,outdir='./_output',solver_type='classic', 
+def setup(state_backend='pyclaw',kernel_language='Fortran',outdir='./_output',solver_type='classic',
         time_integrator='SSP104', disable_output=False):
     """
     Example python script for solving the 2d acoustics equations.
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='classic':
         solver=pyclaw.ClawSolver2D(riemann.vc_acoustics_2D)

--- a/examples/acoustics_3d_variable/acoustics_3d_interface.py
+++ b/examples/acoustics_3d_variable/acoustics_3d_interface.py
@@ -3,23 +3,20 @@
 
 import numpy as np
 
-def setup(use_petsc=False,outdir='./_output',solver_type='classic',disable_output=False,**kwargs):
+def setup(state_backend='pyclaw',outdir='./_output',solver_type='classic',disable_output=False,**kwargs):
     """
     Example python script for solving the 3d acoustics equations.
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='classic':
         solver=pyclaw.ClawSolver3D(riemann.vc_acoustics_3D)
         solver.limiters = pyclaw.limiters.tvd.MC
     elif solver_type=='sharpclaw':
         solver = pyclaw.SharpClawSolver3D(riemann.vc_acoustics_3D)
-        
+
     else:
         raise Exception('Unrecognized solver_type.')
 

--- a/examples/advection_1d/advection_1d.py
+++ b/examples/advection_1d/advection_1d.py
@@ -17,25 +17,22 @@ The final solution is identical to the initial data because the wave has
 crossed the domain exactly once.
 """
 
-def setup(nx=100, kernel_language='Python', use_petsc=False, solver_type='classic', weno_order=5, 
+def setup(state_backend='pyclaw', nx=100, kernel_language='Python',solver_type='classic', weno_order=5,
         time_integrator='SSP104', outdir='./_output'):
     import numpy as np
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='classic':
         if kernel_language == 'Fortran':
             solver = pyclaw.ClawSolver1D(riemann.advection_1D)
-        elif kernel_language=='Python': 
+        elif kernel_language=='Python':
             solver = pyclaw.ClawSolver1D(riemann.advection_1D_py.advection_1D)
     elif solver_type=='sharpclaw':
         if kernel_language == 'Fortran':
             solver = pyclaw.SharpClawSolver1D(riemann.advection_1D)
-        elif kernel_language=='Python': 
+        elif kernel_language=='Python':
             solver = pyclaw.SharpClawSolver1D(riemann.advection_1D_py.advection_1D)
         solver.weno_order=weno_order
         solver.time_integrator=time_integrator

--- a/examples/advection_1d_variable/variable_coefficient_advection.py
+++ b/examples/advection_1d_variable/variable_coefficient_advection.py
@@ -47,25 +47,22 @@ def auxinit(state):
     # Initilize petsc Structures for aux
     xc=state.grid.x.centers
     state.aux[0,:] = np.sin(2.*np.pi*xc)+2
-    
 
-def setup(use_petsc=False,solver_type='classic',kernel_language='Python',outdir='./_output'):
+
+def setup(state_backend='pyclaw',solver_type='classic',kernel_language='Python',outdir='./_output'):
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='classic':
         if kernel_language == 'Fortran':
             solver = pyclaw.ClawSolver1D(riemann.vc_advection_1D)
-        elif kernel_language=='Python': 
+        elif kernel_language=='Python':
             solver = pyclaw.ClawSolver1D(riemann.vc_advection_1D_py.vc_advection_1D)
     elif solver_type=='sharpclaw':
         if kernel_language == 'Fortran':
             solver = pyclaw.SharpClawSolver1D(riemann.vc_advection_1D)
-        elif kernel_language=='Python': 
+        elif kernel_language=='Python':
             solver = pyclaw.SharpClawSolver1D(riemann.vc_advection_1D_py.vc_advection_1D)
         solver.weno_order=weno_order
     else: raise Exception('Unrecognized value of solver_type.')

--- a/examples/advection_2d/advection_2d.py
+++ b/examples/advection_2d/advection_2d.py
@@ -29,17 +29,14 @@ def qinit(state):
                 state.q[:,i,j] = 1.0
             else:
                 state.q[:,i,j] = 0.1
-                
-def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
+
+def setup(state_backend='pyclaw',outdir='./_output',solver_type='classic'):
     """
     Example python script for solving the 2d advection equation.
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='classic':
         solver = pyclaw.ClawSolver2D(riemann.advection_2D)

--- a/examples/advection_2d_annulus/advection_annulus.py
+++ b/examples/advection_2d_annulus/advection_annulus.py
@@ -193,13 +193,10 @@ def stream(xp,yp):
     return streamValue
 
 
-def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
+def setup(state_backend='pyclaw',outdir='./_output',solver_type='classic'):
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type == 'classic':
         solver = pyclaw.ClawSolver2D(riemann.vc_advection_2D)

--- a/examples/burgers_1d/burgers_1d.py
+++ b/examples/burgers_1d/burgers_1d.py
@@ -17,36 +17,33 @@ The initial condition is sinusoidal, but after a short time a shock forms
 (due to the nonlinearity).
 """
 
-def setup(use_petsc=0,kernel_language='Fortran',outdir='./_output',solver_type='classic'):
+def setup(state_backend='pyclaw',kernel_language='Fortran',outdir='./_output',solver_type='classic'):
     """
     Example python script for solving the 1d Burgers equation.
     """
 
     import numpy as np
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     #===========================================================================
     # Setup solver and solver parameters
     #===========================================================================
     if solver_type=='sharpclaw':
-        if kernel_language=='Python': 
+        if kernel_language=='Python':
             solver = pyclaw.SharpClawSolver1D(riemann.burgers_1D_py.burgers_1D)
         elif kernel_language=='Fortran':
             solver = pyclaw.SharpClawSolver1D(riemann.burgers_1D)
     else:
-        if kernel_language=='Python': 
+        if kernel_language=='Python':
             solver = pyclaw.ClawSolver1D(riemann.burgers_1D_py.burgers_1D)
         elif kernel_language=='Fortran':
             solver = pyclaw.ClawSolver1D(riemann.burgers_1D)
         solver.limiters = pyclaw.limiters.tvd.vanleer
 
     solver.kernel_language = kernel_language
-        
+
     solver.bc_lower[0] = pyclaw.BC.periodic
     solver.bc_upper[0] = pyclaw.BC.periodic
 

--- a/examples/euler_1d/shocksine.py
+++ b/examples/euler_1d/shocksine.py
@@ -17,17 +17,14 @@ c = np.array([0., .3772689153313680, .7545378306627360, .7289856616121880, .6992
 
 b = np.array([.206734020864804, .206734020864804, .117097251841844, .181802560120140, .287632146308408])
 
-def setup(use_petsc=False,iplot=False,htmlplot=False,outdir='./_output',solver_type='sharpclaw',kernel_language='Fortran'):
+def setup(state_backend='pyclaw',iplot=False,htmlplot=False,outdir='./_output',solver_type='sharpclaw',kernel_language='Fortran'):
     """
     Solve the Euler equations of compressible fluid dynamics.
     This example involves a shock wave impacting a sinusoidal density field.
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='sharpclaw':
         solver = pyclaw.SharpClawSolver1D(riemann.euler_with_efix_1D)

--- a/examples/euler_1d/woodward_colella_blast.py
+++ b/examples/euler_1d/woodward_colella_blast.py
@@ -21,18 +21,15 @@ involving the collision of two shock waves.
 gamma = 1.4
 gamma1 = gamma - 1.
 
-def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
+def setup(state_backend='pyclaw',outdir='./_output',solver_type='classic'):
     """
     Solve the Euler equations of compressible fluid dynamics.
     This example involves a pair of interacting shock waves.
     The conserved quantities are density, momentum density, and total energy density.
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='sharpclaw':
         solver = pyclaw.SharpClawSolver1D(riemann.euler_with_efix_1D)

--- a/examples/euler_2d/shock_bubble_interaction.py
+++ b/examples/euler_2d/shock_bubble_interaction.py
@@ -154,7 +154,7 @@ def dq_Euler_radial(solver,state,dt):
 
     return dq
 
-def setup(use_petsc=False,kernel_language='Fortran',solver_type='classic',
+def setup(state_backend='pyclaw',kernel_language='Fortran',solver_type='classic',
           outdir='_output', disable_output=False, mx=320, my=80, tfinal=0.6,
           num_output_times = 10):
     """
@@ -162,16 +162,13 @@ def setup(use_petsc=False,kernel_language='Fortran',solver_type='classic',
     This example involves a bubble of dense gas that is impacted by a shock.
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if kernel_language != 'Fortran':
         raise Exception('Unrecognized value of kernel_language for Euler Shockbubble')
 
-    
+
     if solver_type=='sharpclaw':
         solver = pyclaw.SharpClawSolver2D(riemann.euler_5wave_2D)
         solver.dq_src=dq_Euler_radial

--- a/examples/euler_2d/shockbubble_scipy.py
+++ b/examples/euler_2d/shockbubble_scipy.py
@@ -159,17 +159,14 @@ def step_Euler_radial(solver,state,dt):
     q[3,:,:] = q[3,:,:] - dt*(ndim-1)/rad * v * (qstar[3,:,:] + press)
 
 
-def shockbubble(use_petsc=False,outdir='./_output',solver_type='classic'):
+def shockbubble(state_backend='pyclaw',outdir='./_output',solver_type='classic'):
     """
     Solve the Euler equations of compressible fluid dynamics.
     This example involves a bubble of dense gas that is impacted by a shock.
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='sharpclaw':
         solver = pyclaw.SharpClawSolver2D(riemann.euler_5wave_2D)

--- a/examples/kpp/kpp.py
+++ b/examples/kpp/kpp.py
@@ -23,16 +23,13 @@ def qinit(state,rad=1.0):
     state.q[0,:,:] = 0.25*np.pi + 3.25*np.pi*(r<=rad)
 
 
-def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
+def setup(state_backend='pyclaw',outdir='./_output',solver_type='classic'):
     """
     Example python script for solving the 2d KPP equations.
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='sharpclaw':
         solver = pyclaw.SharpClawSolver2D(riemann.kpp_2D)

--- a/examples/psystem_2d/psystem_2d.py
+++ b/examples/psystem_2d/psystem_2d.py
@@ -115,26 +115,23 @@ def total_energy(state):
     potential = (sigma-np.log(sigma+1.))/K
 
     dx=state.grid.delta[0]; dy=state.grid.delta[1]
-    
-    state.F[0,:,:] = (potential+kinetic)*dx*dy 
+
+    state.F[0,:,:] = (potential+kinetic)*dx*dy
 
 def gauge_stress(q,aux):
     p = np.exp(q[0]*aux[1])-1
     return [p,10*p]
 
 def setup(kernel_language='Fortran',
-              use_petsc=False,outdir='./_output',solver_type='classic',
+              state_backend='pyclaw',outdir='./_output',solver_type='classic',
               disable_output=False, cells_per_layer=30, tfinal=18.):
 
     """
     Solve the p-system in 2D with variable coefficients
     """
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     # material parameters
     KA=1.;   rhoA=1.

--- a/examples/shallow_1d/shallow_water_shocktube.py
+++ b/examples/shallow_1d/shallow_water_shocktube.py
@@ -15,24 +15,21 @@ Solve the one-dimensional shallow water equations:
 Here h is the depth, (u,v) is the velocity, and g is the gravitational constant.
 """
 
-    
-def setup(use_petsc=False,kernel_language='Fortran',outdir='./_output',solver_type='classic'):
+
+def setup(state_backend='pyclaw',kernel_language='Fortran',outdir='./_output',solver_type='classic'):
     #===========================================================================
     # Import libraries
     #===========================================================================
     import numpy as np
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if kernel_language =='Python':
         rs = riemann.shallow_1D_py.shallow_1D
     elif kernel_language =='Fortran':
         rs = riemann.shallow_roe_with_efix_1D
- 
+
     if solver_type == 'classic':
         solver = pyclaw.ClawSolver1D(rs)
         solver.limiters = pyclaw.limiters.tvd.vanleer

--- a/examples/shallow_2d/radial_dam_break.py
+++ b/examples/shallow_2d/radial_dam_break.py
@@ -25,17 +25,14 @@ def qinit(state,hl,ul,vl,hr,ur,vr,radDam):
     state.q[1,:,:] = hl*ul*(r<=radDam) + hr*ur*(r>radDam)
     state.q[2,:,:] = hl*vl*(r<=radDam) + hr*vr*(r>radDam)
 
-    
-def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
+
+def setup(state_backend='pyclaw',outdir='./_output',solver_type='classic'):
     #===========================================================================
     # Import libraries
     #===========================================================================
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     #===========================================================================
     # Setup solver and solver parameters

--- a/examples/shallow_sphere/Rossby_wave.py
+++ b/examples/shallow_sphere/Rossby_wave.py
@@ -350,15 +350,15 @@ def auxbc_upper_y(state,dim,t,auxbc,num_ghost):
     mx, my = grid.num_cells[0], grid.num_cells[1]
     xlower, ylower = grid.lower[0], grid.lower[1]
     dx, dy = grid.delta[0],grid.delta[1]
-    
+
     # Impose BC
     auxtemp = auxbc.copy()
     auxtemp = problem.setaux(mx,my,num_ghost,mx,my,xlower,ylower,dx,dy,auxtemp,Rsphere)
     auxbc[:,:,-num_ghost:] = auxtemp[:,:,-num_ghost:]
 
 
-def setup(use_petsc=False,solver_type='classic',outdir='./_output', disable_output=False):
-    if use_petsc:
+def setup(state_backend='pyclaw',solver_type='classic',outdir='./_output', disable_output=False):
+    if state_backend == 'petclaw':
         raise Exception("petclaw does not currently support mapped grids (go bug Lisandro who promised to implement them)")
 
     if solver_type != 'classic':

--- a/examples/stegoton_1d/stegoton.py
+++ b/examples/stegoton_1d/stegoton.py
@@ -84,13 +84,10 @@ def moving_wall_bc(state,dim,t,qbc,num_ghost):
 
 
 
-def setup(use_petsc=0,kernel_language='Fortran',solver_type='classic',outdir='./_output'):
+def setup(state_backend='pyclaw',kernel_language='Fortran',solver_type='classic',outdir='./_output'):
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if kernel_language=='Python':
         rs = riemann.nonlinear_elasticity_1D_py.nonlinear_elasticity_1D

--- a/examples/traffic/traffic.py
+++ b/examples/traffic/traffic.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-def setup(use_petsc=0,outdir='./_output',solver_type='classic'):
+def setup(state_backend='pyclaw',outdir='./_output',solver_type='classic'):
     """
     Example python script for solving 1d traffic model:
 
@@ -10,11 +10,8 @@ def setup(use_petsc=0,outdir='./_output',solver_type='classic'):
 
     import numpy as np
     from clawpack import riemann
-
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     #===========================================================================
     # Setup solver and solver parameters

--- a/fvmbook/chap7/standing/acoustics.py
+++ b/fvmbook/chap7/standing/acoustics.py
@@ -1,20 +1,15 @@
 #!/usr/bin/env python
 # encoding: utf-8
-    
-def acoustics(use_petsc=False,kernel_language='Fortran',solver_type='classic',iplot=False,htmlplot=False,outdir='./_output',weno_order=5):
+
+def acoustics(state_backend='pyclaw',kernel_language='Fortran',solver_type='classic',iplot=False,htmlplot=False,outdir='./_output',weno_order=5):
     """
     This example solves the 1-dimensional acoustics equations in a homogeneous
     medium.
     """
     import numpy as np
 
-    #=================================================================
-    # Import the appropriate classes, depending on the options passed
-    #=================================================================
-    if use_petsc:
-        import clawpack.petclaw as pyclaw
-    else:
-        from clawpack import pyclaw
+    from clawpack.pyclaw.util import get_state_backend
+    pyclaw = get_state_backend(state_backend)
 
     if solver_type=='classic':
         solver = pyclaw.ClawSolver1D()


### PR DESCRIPTION
This PR moves the

```
if use_petsc:
  import clawpack.petclaw as pyclaw
else:
  from clawpack import pyclaw
```

logic that is current present in most (all?) examples into the 'run_app_from_main' utility.  This will allow new backends to be tested without repeating the above logic in every application.  For example, suppose a new backend called 'boxclaw' is created.  Currently one would have to change the above code snippet to:

```
if use_petsc:
  import clawpack.petclaw as pyclaw
elif use_boxlib:
  import clawpack.boxclaw as pyclaw
else:
  from clawpack import pyclaw
```

in every example.

At this time I have only modified one example to demonstrate the intended usage.
