### PR TITLE
 hdf5 and netcdf write/read support in petsc io + example

### DIFF
--- a/examples/acoustics_2d_variable/acoustics_2d_interface.py
+++ b/examples/acoustics_2d_variable/acoustics_2d_interface.py
@@ -88,6 +88,8 @@ def setup(kernel_language='Fortran',use_petsc=False,outdir='./_output',solver_ty
     claw.num_output_times = 20
     claw.write_aux_init = True
     claw.setplot = setplot
+    if use_petsc:
+        claw.output_options = {'format':'binary'}
 
     # Solve
     claw.tfinal = 0.6

--- a/examples/acoustics_2d_variable/test_acoustics_2d_variable_io.py
+++ b/examples/acoustics_2d_variable/test_acoustics_2d_variable_io.py
@@ -28,13 +28,15 @@ def test_acoustics_2d_variable_io():
         sol_0_test = Solution()
         sol_0_test.read(0,path=controller.outdir,
                         file_format=controller.output_format,
-                        file_prefix=None,read_aux=True)
+                        file_prefix=None,read_aux=True,
+                        options=controller.output_options)
         test_aux = sol_0_test.state.get_aux_global()
 
         sol_20_test = Solution()
         sol_20_test.read(20,path=controller.outdir,
                         file_format=controller.output_format,
-                        file_prefix=None,read_aux=False)
+                        file_prefix=None,read_aux=False,
+                        options=controller.output_options)
         test_q = sol_20_test.state.get_q_global()
 
 


### PR DESCRIPTION
This PR... 
- adds the ability to write and read hdf5 and netcdf when using petsc. The options are passed through a dictionary set in output_options={'format':'hdf5'}.
- adds one more value to the pickle: file_format, It is key for the xmf writer to figure out what format the data is in. The pkl2xmf writer will allow to load the results directly into paraview. (https://gist.github.com/sanromd/11346554)
- Add an example of write/read on acoustics_2d_variable.
- Modification to the warning mechanism in petsc io read routine. 
