### PR TITLE
Fix calculation of ghost cell centers

### DIFF
--- a/src/pyclaw/geometry.py
+++ b/src/pyclaw/geometry.py
@@ -126,7 +126,7 @@ class Grid(object):
         r"""(list of ndarray(...)) - List containing the arrays locating
                 the computational locations of cell centers, see 
                 :meth:`compute_c_centers` for more info."""
-        self.compute_c_centers_with_ghost(self,num_ghost)
+        self.compute_c_centers_with_ghost(self,num_ghost,recompute=True)
         return self._c_centers_with_ghost
     _c_centers_with_ghost = None
     @property


### PR DESCRIPTION
This PR fixes a bug introduced in PR  #384 where `compute_c_centers()` and `compute_c_edges` were extended to include also `ghost_cells`.  The bug introduced made the feature unusable in 1D and was unable to recompute when `recompute=True`. 

An example of how to access `cell_centers`

```
    x = pyclaw.Dimension('x',x_lower,x_upper,mx)
    y = pyclaw.Dimension('y',y_lower,y_upper,my)
    z = pyclaw.Dimension('z',z_lower,z_upper,mz)

    domain = pyclaw.Domain([x,y,z])
    state = pyclaw.State(domain,num_eqn,num_aux)

    grid = state.grid
    grid.compute_c_centers()
    X,Y,Z = grid._c_centers
```

for `cell_centers_with_ghost`

```
    grid = state.grid
    grid.compute_c_centers_with_ghost(num_ghost)
    X,Y,Z = grid._c_centers_with_ghost
```
