### PR TITLE
Fix loop bounds that didn't include enough ghost cells.

### DIFF
--- a/src/pyclaw/sharpclaw/reconstruct.f90
+++ b/src/pyclaw/sharpclaw/reconstruct.f90
@@ -601,7 +601,7 @@ contains
 
             ! compute and store the differences of the cell averages
 
-            do i=num_ghost+1,mx2-num_ghost
+            do i=2,mx2-1
                 dqm=dqp
                 dqp=q(m,i+1)-q(m,i)
                 r=dqp/dqm


### PR DESCRIPTION
This bug was causing the test failures seen in https://github.com/clawpack/pyclaw/pull/398.
