### PR TITLE
changed argument of test_app in line 172 in util.py to verifier

### DIFF
--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -169,7 +169,7 @@ def gen_variants(application, verifier, kernel_languages=('Fortran',), **kwargs)
             solver_info = 'solver_type={solver_type!s}, '
         else:
             solver_info = ''
-        test = lambda: test_app(application, verifiers, test_kwargs)
+        test = lambda: test_app(application, verifier, test_kwargs)
         test.description = ('{test_name!s}(kernel_language={kernel_language!s}, ' +
                             solver_info + 'use_petsc={use_petsc!s})').format(test_name=test_name, **test_kwargs)
         yield test


### PR DESCRIPTION
In a recent merge an "s" was added to the argument resulting in nose failing all tests. Note that the function `gen_variants` has as input the argument `verifier` 
