### PR TITLE
Forward-facing step example

### DIFF
--- a/examples/euler_2d/Makefile
+++ b/examples/euler_2d/Makefile
@@ -1,2 +1,2 @@
-riemannsolver.so: rpn2_euler_4wave_boundary.f90
-	f2py -m riemannsolver -c rpn2_euler_4wave_boundary.f90
+euler_with_boundaries.so: rpn2_euler_4wave_boundary.f90
+	f2py -m euler_with_boundaries -c rpn2_euler_4wave_boundary.f90

--- a/examples/euler_2d/rpn2_euler_4wave_boundary.f90
+++ b/examples/euler_2d/rpn2_euler_4wave_boundary.f90
@@ -2,28 +2,35 @@
 subroutine rpn2(ixy,maxm,meqn,mwaves,maux,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apdq)
 ! =====================================================
 !
-!     # Roe-solver for the Euler equations
-!     # mwaves = 4:  separate shear and entropy waves.
+!     Roe solver for the Euler equations with internal boundaries
+!     mwaves = 4:  separate shear and entropy waves.
 !
-!     # solve Riemann problems along one slice of data.
+!     The aux array contains the geometry.  Where it is equal
+!     to one, the cell is inside the domain.  Where it is
+!     equal to zero, the cell is outside the domain.
 !
-!     # On input, ql contains the state vector at the left edge of each cell
-!     #           qr contains the state vector at the right edge of each cell
+!     This should only be used with dimensional splitting,
+!     since we haven't yet written a corresponding transverse solver.
 !
-!     # This data is along a slice in the x-direction if ixy=1 
-!     #                            or the y-direction if ixy=2.
-!     # On output, wave contains the waves, s the speeds, 
-!     # and amdq, apdq the decomposition of the flux difference
-!     #   f(qr(i-1)) - f(ql(i))  
-!     # into leftgoing and rightgoing parts respectively.
-!     # With the Roe solver we have   
-!     #    amdq  =  A^- \Delta q    and    apdq  =  A^+ \Delta q
-!     # where A is the Roe matrix.  An entropy fix can also be incorporated
-!     # into the flux differences.
+!     solve Riemann problems along one slice of data.
 !
-!     # Note that the i'th Riemann problem has left state qr(:,i-1)
-!     #                                    and right state ql(:,i)
-!     # From the basic clawpack routines, this routine is called with ql = qr
+!     On input, ql contains the state vector at the left edge of each cell
+!               qr contains the state vector at the right edge of each cell
+!
+!     This data is along a slice in the x-direction if ixy=1 
+!                                or the y-direction if ixy=2.
+!     On output, wave contains the waves, s the speeds, 
+!     and amdq, apdq the decomposition of the flux difference
+!       f(qr(i-1)) - f(ql(i))  
+!     into leftgoing and rightgoing parts respectively.
+!     With the Roe solver we have   
+!        amdq  =  A^- \Delta q    and    apdq  =  A^+ \Delta q
+!     where A is the Roe matrix.  An entropy fix can also be incorporated
+!     into the flux differences.
+!
+!     Note that the i'th Riemann problem has left state qr(:,i-1)
+!                                        and right state ql(:,i)
+!     From the basic clawpack routines, this routine is called with ql = qr
 !
 !
       implicit double precision (a-h,o-z)

--- a/examples/euler_2d/shock_forward_step.py
+++ b/examples/euler_2d/shock_forward_step.py
@@ -1,108 +1,110 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
-Compressible Euler flow in cylindrical symmetry
-===============================================
+Compressible Euler flow over a forward-facing step
+==================================================
 
-Solve the Euler equations of compressible fluid dynamics in 2D r-z coordinates:
+Solve the Euler equations of compressible fluid dynamics in 2D:
 
 .. math::
-    \rho_t + (\rho u)_x + (\rho v)_y & = - \rho v / r \\
-    (\rho u)_t + (\rho u^2 + p)_x + (\rho uv)_y & = -\rho u v / r \\
-    (\rho v)_t + (\rho uv)_x + (\rho v^2 + p)_y & = - \rho v^2 / r \\
-    E_t + (u (E + p) )_x + (v (E + p))_y & = - (E + p) v / r.
+    \rho_t + (\rho u)_x + (\rho v)_y & = 0 \\
+    (\rho u)_t + (\rho u^2 + p)_x + (\rho uv)_y & = 0 \\
+    (\rho v)_t + (\rho uv)_x + (\rho v^2 + p)_y & = 0 \\
+    E_t + (u (E + p) )_x + (v (E + p))_y & = 0.
+
 
 Here :math:`\rho` is the density, (u,v) is the velocity, and E is the total energy.
-The radial coordinate is denoted by r.
 
-The problem involves a planar shock wave impacting a spherical low-density bubble.
-The problem is 3-dimensional but has been reduced to two dimensions using 
-cylindrical symmetry.
+The problem involves a shock wave impacting a forward-facing step.  A
+stationary shock forms.  When using a Roe solver, there is a carbuncle
+instability.
 
-This problem demonstrates:
-
-    - how to incorporate source (non-hyperbolic) terms using both Classic and SharpClaw solvers
-    - how to impose a custom boundary condition
-    - how to use the auxiliary array for spatially-varying coefficients
+This example demonstrates how to include internal boundaries within the
+domain.  An aux array field is used to indicate which cells are inside (1)
+or outside (0) of the domain.  A special Riemann solver enforces reflecting
+boundary conditions at the internal boundaries.  This could be modified
+to handle other internal boundary geometries, as long as they are
+aligned with the grid.
 """
-
-import numpy as np
-from clawpack import riemann
 
 gamma = 1.4 # Ratio of specific heats
 gamma1 = gamma - 1.
-x0=0.5; y0=0.; r0=0.2
 
 def incoming_shock(state,dim,t,qbc,num_ghost):
     """
     Incoming shock at left boundary.
     """
     rho = 1.4;
-    ux = 3.0;
-    uy = 0.0;
-    p = 1.0;
-    T = 2*p/rho;
+    u   = 3.0;
+    v   = 0.0;
+    p   = 1.0;
+    T   = 2*p/rho;
 
     for i in xrange(num_ghost):
         qbc[0,i,...] = rho
-        qbc[1,i,...] = rho*ux
-        qbc[2,i,...] = rho*uy
-        qbc[3,i,...] = rho*(5.0/4 * T + (ux**2+uy**2)/2.)
+        qbc[1,i,...] = rho*u
+        qbc[2,i,...] = rho*v
+        qbc[3,i,...] = rho*(5.0/4 * T + (u**2+v**2)/2.)
 
 
 def setup(use_petsc=False,solver_type='classic', outdir='_output', kernel_language='Fortran',
-        disable_output=False, mx=320, my=80, tfinal=2.0, num_output_times = 10):
+          disable_output=False, mx=320, my=80, tfinal=2.0, num_output_times = 10):
+
     if use_petsc:
         import clawpack.petclaw as pyclaw
     else:
         from clawpack import pyclaw
 
-    import riemannsolver
+    try:
+        import euler_with_boundaries
+    except ImportError:
+        raise Exception("Please run make in this directory to compile the Riemann solver.")
 
     if solver_type=='sharpclaw':
-        solver = pyclaw.SharpClawSolver2D(riemannsolver)
+        #solver = pyclaw.SharpClawSolver2D(euler_with_boundaries)
+        raise Exception('This problem does not currently work with SharpClaw')
     else:
-        solver = pyclaw.ClawSolver2D(riemannsolver)
+        solver = pyclaw.ClawSolver2D(euler_with_boundaries)
         solver.dimensional_split = True
 
     solver.num_eqn = 4
     solver.num_waves = 4
+    num_aux = 1
+
     x = pyclaw.Dimension('x',0.0,3.0,mx)
     y = pyclaw.Dimension('y',0.0,1.0,my)
     domain = pyclaw.Domain([x,y])
 
-    num_aux=1
     state = pyclaw.State(domain,solver.num_eqn,num_aux)
     state.problem_data['gamma']= gamma
     state.problem_data['gamma1']= gamma1
 
-    solver.cfl_max = 0.5
-    solver.cfl_desired = 0.45
-    solver.dt_initial=0.005
     solver.user_bc_lower = incoming_shock
 
     solver.bc_lower[0]=pyclaw.BC.custom
     solver.bc_upper[0]=pyclaw.BC.extrap
     solver.bc_lower[1]=pyclaw.BC.wall
     solver.bc_upper[1]=pyclaw.BC.wall
-    #Aux variable in ghost cells doesn't matter
+
     solver.aux_bc_lower[0]=pyclaw.BC.extrap
     solver.aux_bc_upper[0]=pyclaw.BC.extrap
     solver.aux_bc_lower[1]=pyclaw.BC.wall
     solver.aux_bc_upper[1]=pyclaw.BC.wall
 
     rho = 1.4;
-    ux = 3.0;
-    uy = 0.;
+    u = 3.0;
+    v = 0.;
     p = 1.0;
     T = 2*p/rho;
 
     state.q[0,...] = rho;
-    state.q[1,...] = rho*ux;
-    state.q[2,...] = rho*uy;
-    state.q[3,...] = rho*(5.0/4 * T + (ux**2+uy**2)/2.);
+    state.q[1,...] = rho*u;
+    state.q[2,...] = rho*v;
+    state.q[3,...] = rho*(5.0/4 * T + (u**2+v**2)/2.);
 
     x,y = domain.grid.p_centers
+
+    # Set aux values to zero inside step, to unity elsewhere
     state.aux[0,...]= 1 - (x > 0.6)*(y < 0.2)
 
     claw = pyclaw.Controller()
@@ -121,9 +123,7 @@ def setup(use_petsc=False,solver_type='classic', outdir='_output', kernel_langua
 
     
 def setplot(plotdata):
-    """ 
-    Plot solution using VisClaw.
-    """ 
+    "Plot solution using VisClaw." 
     from clawpack.visclaw import colormaps
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
@@ -137,9 +137,9 @@ def setplot(plotdata):
     plotaxes.afteraxes = fill_step
     #plotitem = plotaxes.new_plotitem(plot_type='2d_schlieren')
     plotitem = plotaxes.new_plotitem(plot_type='2d_pcolor')
-    plotitem.pcolor_cmin = 1
-    plotitem.pcolor_cmax=7.0
     plotitem.plot_var = 0
+    plotitem.pcolor_cmin = 1
+    plotitem.pcolor_cmax = 7.0
     plotitem.add_colorbar = True
     
 
@@ -161,6 +161,7 @@ def setplot(plotdata):
     return plotdata
    
 def fill_step(currentdata):
+    "Fill the step area with a black rectangle."
     import matplotlib.pyplot as plt
     plt.hold(True);
     rectangle = plt.Rectangle((0.6,0.0),2.4,0.2,color="k",fill=True)


### PR DESCRIPTION
This builds on and replaces #445.  Mainly, I've edited the comments to better document this example.  There are some unfortunate things:
- Using the Roe solver (and Classic) we get a carbuncle instability after a short time.  I understand the solution is to use an HLL solver.
- The approach we're using for internal boundaries seems to work well for Classic, but not for SharpClaw.  I think this is because the values used for reconstruction don't make sense after a while.  We could implement a different approach, in which cell values inside the step are overwritten in a `before_step` routine, but there is then ambiguity in what value to write to cells near the corner of the step.
