### PR TITLE
Use apt-get to install scipy (binary) on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ env:
   - TEST_PACKAGE="petclaw"
 python:
   - 2.7
+virtualenv:
+  system_site_package: true
 before_install:
   - pip install coverage
   - pip install python-coveralls
   - sudo apt-get update -qq
-  - sudo apt-get install -qq gfortran liblapack-pic
+  - sudo apt-get install -qq gfortran liblapack-pic python-scipy
   - if [[ "${TEST_PACKAGE}" == "petclaw" ]]; then
       sudo apt-get install pv mpich2 liblapack-dev;
     fi


### PR DESCRIPTION
Following suggestions from http://danielnouri.org/notes/2012/11/23/use-apt-get-to-install-python-dependencies-for-travis-ci/.

**Current status**: Travis is still not seeing our scipy install, so the test that relies on it gets skipped.  Not sure why.