### PR TITLE
Make sure setplot_func variable always gets defined.

### DIFF
--- a/src/pyclaw/plot.py
+++ b/src/pyclaw/plot.py
@@ -16,6 +16,7 @@ def plot(setplot=None, outdir="./_output", plotdir=None, htmlplot=False,
             plotdir = os.path.join(os.getcwd(),"_plots")
     
     if htmlplot or iplot:
+        setplot_func = None
         # No setplot specified, try to use a local file
         if setplot is None:
             # Grab and import the setplot function


### PR DESCRIPTION
This PR avoids a bug where `setplot_func` is not set to anything in `pyclaw.plot`.  Thanks to Imre Fekete for catching this bug.
