### PR TITLE
Allow specification of which field to reflect for wall BCs.

### DIFF
--- a/src/pyclaw/classic/solver.py
+++ b/src/pyclaw/classic/solver.py
@@ -277,6 +277,7 @@ class ClawSolver1D(ClawSolver):
         See :class:`ClawSolver1D` for more info.
         """   
         self.num_dim = 1
+        self.reflect_index = [1]
 
         super(ClawSolver1D,self).__init__(riemann_solver, claw_package)
 
@@ -448,6 +449,7 @@ class ClawSolver2D(ClawSolver):
         self.transverse_waves = self.trans_inc
 
         self.num_dim = 2
+        self.reflect_index = [1,2]
 
         self.aux1 = None
         self.aux2 = None
@@ -610,6 +612,7 @@ class ClawSolver3D(ClawSolver):
         self.transverse_waves = self.trans_cor
 
         self.num_dim = 3
+        self.reflect_index = [1,2,3]
 
         self.aux1 = None
         self.aux2 = None

--- a/src/pyclaw/sharpclaw/solver.py
+++ b/src/pyclaw/sharpclaw/solver.py
@@ -619,6 +619,7 @@ class SharpClawSolver1D(SharpClawSolver):
         See :class:`SharpClawSolver1D` for more info.
         """   
         self.num_dim = 1
+        self.reflect_index = [1]
         super(SharpClawSolver1D,self).__init__(riemann_solver,claw_package)
 
 
@@ -755,6 +756,7 @@ class SharpClawSolver2D(SharpClawSolver):
         See :class:`SharpClawSolver2D` for more info.
         """   
         self.num_dim = 2
+        self.reflect_index = [1,2]
 
         super(SharpClawSolver2D,self).__init__(riemann_solver,claw_package)
 
@@ -826,6 +828,7 @@ class SharpClawSolver3D(SharpClawSolver):
         See :class:`SharpClawSolver3D` for more info.
         """   
         self.num_dim = 3
+        self.reflect_index = [1,2,3]
 
         super(SharpClawSolver3D,self).__init__(riemann_solver,claw_package)
 

--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -452,7 +452,7 @@ class Solver(object):
             if name == 'q':
                 for i in xrange(self.num_ghost):
                     array[:,i,...] = array[:,2*self.num_ghost-1-i,...]
-                    array[idim+1,i,...] = -array[idim+1,2*self.num_ghost-1-i,...] # Negate normal velocity
+                    array[self.reflect_index[idim],i,...] = -array[self.reflect_index[idim],2*self.num_ghost-1-i,...] # Negate normal velocity
             else:
                 for i in xrange(self.num_ghost):
                     array[:,i,...] = array[:,2*self.num_ghost-1-i,...]
@@ -489,7 +489,7 @@ class Solver(object):
             if name == 'q':
                 for i in xrange(self.num_ghost):
                     array[:,-i-1,...] = array[:,-2*self.num_ghost+i,...]
-                    array[idim+1,-i-1,...] = -array[idim+1,-2*self.num_ghost+i,...] # Negate normal velocity
+                    array[self.reflect_index[idim],-i-1,...] = -array[self.reflect_index[idim],-2*self.num_ghost+i,...] # Negate normal velocity
             else:
                 for i in xrange(self.num_ghost):
                     array[:,-i-1,...] = array[:,-2*self.num_ghost+i,...]


### PR DESCRIPTION
For some systems, and depending on how the q fields are ordered, it may be useful to reflect different fields at "wall" boundaries.  This makes it possible to do so by setting e.g.

```
solver.reflect_index = [2,3,1]
```
