### PR TITLE
Add sill example

### DIFF
--- a/examples/shallow_1d/sill.py
+++ b/examples/shallow_1d/sill.py
@@ -18,7 +18,7 @@ the bathymetry.
 import numpy
 from clawpack import riemann
 
-def setup(use_petsc=False, outdir='./_output', solver_type='classic'):
+def setup(kernel_language='Python',use_petsc=False, outdir='./_output', solver_type='classic'):
 
     if use_petsc:
         import clawpack.petclaw as pyclaw
@@ -56,9 +56,14 @@ def setup(use_petsc=False, outdir='./_output', solver_type='classic'):
     claw.tfinal = 1.0
     claw.solution = pyclaw.Solution(state, domain)
     claw.solver = solver
-    claw.outdir = outdir
     claw.setplot = setplot
     claw.write_aux_init = True
+
+    if outdir is not None:
+        claw.outdir = outdir
+    else:
+        claw.output_format = None
+
 
     return claw
 

--- a/examples/shallow_1d/test_sill.py
+++ b/examples/shallow_1d/test_sill.py
@@ -20,15 +20,14 @@ def test_1d_sill():
 
             if q0 != None and qfinal != None:
                 dx = claw.solution.domain.grid.delta[0]
-                test = dx*np.linalg.norm(qfinal-q0,1)
+                test = dx * np.linalg.norm(qfinal - q0, 1)
                 return check_diff(expected, test, reltol=1e-4)
             else:
                 return
         return sill_verify
 
     from clawpack.pyclaw.util import gen_variants
-
-    classic_tests = gen_variants(sill.setup, verify_expected(3.203924e-04), 
+    classic_tests = gen_variants(sill.setup, verify_expected(4.04169269142e-4), 
                                              kernel_languages=["Python"],
                                              solver_type='classic',
                                              outdir=None)
@@ -38,4 +37,5 @@ def test_1d_sill():
         yield test
 
 if __name__=='__main__':
-    test_1d_sill()
+    import nose
+    nose.main()

--- a/examples/shallow_1d/test_sill.py
+++ b/examples/shallow_1d/test_sill.py
@@ -28,9 +28,8 @@ def test_1d_sill():
 
     from clawpack.pyclaw.util import gen_variants
 
-    import pdb; pdb.set_trace()
     classic_tests = gen_variants(sill.setup, verify_expected(3.203924e-04), 
-                                             kernel_languages=("Python"),
+                                             kernel_languages=["Python"],
                                              solver_type='classic',
                                              outdir=None)
 
@@ -39,5 +38,4 @@ def test_1d_sill():
         yield test
 
 if __name__=='__main__':
-    import pdb; pdb.set_trace()
     test_1d_sill()

--- a/examples/shallow_1d/test_sill.py
+++ b/examples/shallow_1d/test_sill.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def test_1d_sill():
+    """test_1d_sill
+
+    tests against expected classic solution of shallow water equations over
+    a sill."""
+
+    import sill
+
+    def verify_expected(expected):
+        """ given an expected value, returns a verification function """
+        def sill_verify(claw):
+            from clawpack.pyclaw.util import check_diff
+            import numpy as np
+
+            q0 = claw.frames[0].state.get_q_global()
+            qfinal = claw.frames[claw.num_output_times].state.get_q_global()
+
+            if q0 != None and qfinal != None:
+                dx = claw.solution.domain.grid.delta[0]
+                test = dx*np.linalg.norm(qfinal-q0,1)
+                return check_diff(expected, test, reltol=1e-4)
+            else:
+                return
+        return sill_verify
+
+    from clawpack.pyclaw.util import gen_variants
+
+    import pdb; pdb.set_trace()
+    classic_tests = gen_variants(sill.setup, verify_expected(3.203924e-04), 
+                                             kernel_languages=("Python"),
+                                             solver_type='classic',
+                                             outdir=None)
+
+    from itertools import chain
+    for test in chain(classic_tests):
+        yield test
+
+if __name__=='__main__':
+    import pdb; pdb.set_trace()
+    test_1d_sill()


### PR DESCRIPTION
This adds an example and test of a pure Python version of a shallow water fwave Riemann solver (see PR https://github.com/clawpack/riemann/pull/82).
