### PR TITLE
Fix warning about elementwise comparison to 'None'.

### DIFF
--- a/examples/shallow_1d/test_sill.py
+++ b/examples/shallow_1d/test_sill.py
@@ -18,7 +18,7 @@ def test_1d_sill():
             q0 = claw.frames[0].state.get_q_global()
             qfinal = claw.frames[claw.num_output_times].state.get_q_global()
 
-            if q0 != None and qfinal != None:
+            if q0 is not None and qfinal is not None:
                 dx = claw.solution.domain.grid.delta[0]
                 test = dx * np.linalg.norm(qfinal - q0, 1)
                 return check_diff(expected, test, reltol=1e-4)

--- a/src/pyclaw/classic/solver.py
+++ b/src/pyclaw/classic/solver.py
@@ -636,7 +636,7 @@ class ClawSolver3D(ClawSolver):
         #with f2py.  It involves wastefully allocating three arrays.
         #f2py seems not able to handle multiple zero-size arrays being passed.
         # it appears the bug is related to f2py/src/fortranobject.c line 841.
-        if(aux == None): num_aux=1
+        if(aux is None): num_aux=1
 
         grid  = state.grid
         maxmx,maxmy,maxmz = grid.num_cells[0],grid.num_cells[1],grid.num_cells[2]


### PR DESCRIPTION
This PR "correctly" checks if an element is `None` and thus elementwise object comparison is avoided.
