### PR TITLE
Deprecate name as first argument to Dimension constructor.

### DIFF
--- a/examples/acoustics_1d_homogeneous/acoustics_1d.py
+++ b/examples/acoustics_1d_homogeneous/acoustics_1d.py
@@ -51,7 +51,7 @@ def setup(use_petsc=False, kernel_language='Fortran', solver_type='classic',
 
     solver.kernel_language=kernel_language
 
-    x = pyclaw.Dimension('x',0.0,1.0,100)
+    x = pyclaw.Dimension(0.0,1.0,100,name='x')
     domain = pyclaw.Domain(x)
     num_eqn = 2
     state = pyclaw.State(domain,num_eqn)

--- a/examples/acoustics_2d_homogeneous/acoustics_2d.py
+++ b/examples/acoustics_2d_homogeneous/acoustics_2d.py
@@ -55,8 +55,8 @@ def setup(kernel_language='Fortran', use_petsc=False, outdir='./_output',
     solver.bc_upper[1]=pyclaw.BC.extrap
 
     mx=100; my=100
-    x = pyclaw.Dimension('x',-1.0,1.0,mx)
-    y = pyclaw.Dimension('y',-1.0,1.0,my)
+    x = pyclaw.Dimension(-1.0,1.0,mx,name='x')
+    y = pyclaw.Dimension(-1.0,1.0,my,name='y')
     domain = pyclaw.Domain([x,y])
 
     num_eqn = 3

--- a/examples/acoustics_2d_variable/acoustics_2d_interface.py
+++ b/examples/acoustics_2d_variable/acoustics_2d_interface.py
@@ -53,8 +53,8 @@ def setup(kernel_language='Fortran', use_petsc=False, outdir='./_output',
     solver.aux_bc_lower[1]=pyclaw.BC.wall
     solver.aux_bc_upper[1]=pyclaw.BC.extrap
 
-    x = pyclaw.Dimension('x',-1.0,1.0,num_cells[0])
-    y = pyclaw.Dimension('y',-1.0,1.0,num_cells[1])
+    x = pyclaw.Dimension(-1.0,1.0,num_cells[0],name='x')
+    y = pyclaw.Dimension(-1.0,1.0,num_cells[1],name='y')
     domain = pyclaw.Domain([x,y])
 
     num_eqn = 3

--- a/examples/acoustics_3d_variable/acoustics_3d_interface.py
+++ b/examples/acoustics_3d_variable/acoustics_3d_interface.py
@@ -92,9 +92,9 @@ def setup(use_petsc=False,outdir='./_output',solver_type='classic',
     solver.limiters = pyclaw.limiters.tvd.MC
 
     # Initialize domain
-    x = pyclaw.Dimension('x',-1.0,1.0,mx)
-    y = pyclaw.Dimension('y',-1.0,1.0,my)
-    z = pyclaw.Dimension('z',-1.0,1.0,mz)
+    x = pyclaw.Dimension(-1.0,1.0,mx,name='x')
+    y = pyclaw.Dimension(-1.0,1.0,my,name='y')
+    z = pyclaw.Dimension(-1.0,1.0,mz,name='z')
     domain = pyclaw.Domain([x,y,z])
 
     num_eqn = 4

--- a/examples/advection_1d/advection_1d.py
+++ b/examples/advection_1d/advection_1d.py
@@ -45,7 +45,7 @@ def setup(nx=100, kernel_language='Python', use_petsc=False, solver_type='classi
     solver.bc_lower[0] = pyclaw.BC.periodic
     solver.bc_upper[0] = pyclaw.BC.periodic
 
-    x = pyclaw.Dimension('x',0.0,1.0,nx)
+    x = pyclaw.Dimension(0.0,1.0,nx,name='x')
     domain = pyclaw.Domain(x)
     state = pyclaw.State(domain,solver.num_eqn)
 

--- a/examples/advection_1d_variable/variable_coefficient_advection.py
+++ b/examples/advection_1d_variable/variable_coefficient_advection.py
@@ -79,7 +79,7 @@ def setup(use_petsc=False,solver_type='classic',kernel_language='Python',outdir=
     solver.aux_bc_upper[0] = 2
 
     xlower=0.0; xupper=1.0; mx=100
-    x    = pyclaw.Dimension('x',xlower,xupper,mx)
+    x    = pyclaw.Dimension(xlower,xupper,mx,name='x')
     domain = pyclaw.Domain(x)
     num_aux=1
     num_eqn = 1

--- a/examples/advection_2d/advection_2d.py
+++ b/examples/advection_2d/advection_2d.py
@@ -50,8 +50,8 @@ def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
 
     # Domain:
     mx = 50; my = 50
-    x = pyclaw.Dimension('x',0.0,1.0,mx)
-    y = pyclaw.Dimension('y',0.0,1.0,my)
+    x = pyclaw.Dimension(0.0,1.0,mx,name='x')
+    y = pyclaw.Dimension(0.0,1.0,my,name='y')
     domain = pyclaw.Domain([x,y])
 
     num_eqn = 1

--- a/examples/advection_2d_annulus/advection_annulus.py
+++ b/examples/advection_2d_annulus/advection_annulus.py
@@ -189,8 +189,8 @@ def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
     theta_upper = np.pi*2.0
     m_theta = 120
 
-    r     = pyclaw.Dimension('r',    r_lower,r_upper,m_r)
-    theta = pyclaw.Dimension('theta',theta_lower,theta_upper,m_theta)
+    r     = pyclaw.Dimension(r_lower,r_upper,m_r,name='r')
+    theta = pyclaw.Dimension(theta_lower,theta_upper,m_theta,name='theta')
     domain = pyclaw.Domain([r,theta])
     domain.grid.mapc2p = mapc2p_annulus
 

--- a/examples/burgers_1d/burgers_1d.py
+++ b/examples/burgers_1d/burgers_1d.py
@@ -42,7 +42,7 @@ def setup(use_petsc=0,kernel_language='Fortran',outdir='./_output',solver_type='
     solver.bc_lower[0] = pyclaw.BC.periodic
     solver.bc_upper[0] = pyclaw.BC.periodic
 
-    x = pyclaw.Dimension('x',0.0,1.0,500)
+    x = pyclaw.Dimension(0.0,1.0,500,name='x')
     domain = pyclaw.Domain(x)
     num_eqn = 1
     state = pyclaw.State(domain,num_eqn)

--- a/examples/euler_1d/shocksine.py
+++ b/examples/euler_1d/shocksine.py
@@ -88,7 +88,7 @@ def setup(use_petsc=False,iplot=False,htmlplot=False,outdir='./_output',solver_t
     solver.bc_upper[0]=pyclaw.BC.extrap
 
     mx = 400;
-    x = pyclaw.Dimension('x',-5.0,5.0,mx)
+    x = pyclaw.Dimension(-5.0,5.0,mx,name='x')
     domain = pyclaw.Domain([x])
     state = pyclaw.State(domain,num_eqn)
 

--- a/examples/euler_1d/woodward_colella_blast.py
+++ b/examples/euler_1d/woodward_colella_blast.py
@@ -92,7 +92,7 @@ def setup(use_petsc=False,outdir='./_output',solver_type='sharpclaw',kernel_lang
     solver.bc_upper[0]=pyclaw.BC.wall
 
     mx = 800;
-    x = pyclaw.Dimension('x',0.0,1.0,mx)
+    x = pyclaw.Dimension(0.0,1.0,mx,name='x')
     domain = pyclaw.Domain([x])
     state = pyclaw.State(domain,num_eqn)
 

--- a/examples/euler_2d/shock_bubble_interaction.py
+++ b/examples/euler_2d/shock_bubble_interaction.py
@@ -194,8 +194,8 @@ def setup(use_petsc=False,solver_type='classic', outdir='_output', kernel_langua
         solver.cfl_max = 0.5
         solver.cfl_desired = 0.45
 
-    x = pyclaw.Dimension('x',0.0,2.0,mx)
-    y = pyclaw.Dimension('y',0.0,0.5,my)
+    x = pyclaw.Dimension(0.0,2.0,mx,name='x')
+    y = pyclaw.Dimension(0.0,0.5,my,name='y')
     domain = pyclaw.Domain([x,y])
 
     num_aux=1

--- a/examples/euler_2d/shock_forward_step.py
+++ b/examples/euler_2d/shock_forward_step.py
@@ -70,8 +70,8 @@ def setup(use_petsc=False,solver_type='classic', outdir='_output', kernel_langua
     solver.num_waves = 4
     num_aux = 1
 
-    x = pyclaw.Dimension('x',0.0,3.0,mx)
-    y = pyclaw.Dimension('y',0.0,1.0,my)
+    x = pyclaw.Dimension(0.0,3.0,mx,name='x')
+    y = pyclaw.Dimension(0.0,1.0,my,name='y')
     domain = pyclaw.Domain([x,y])
 
     state = pyclaw.State(domain,solver.num_eqn,num_aux)

--- a/examples/euler_3d/Sedov.py
+++ b/examples/euler_3d/Sedov.py
@@ -57,9 +57,9 @@ def setup(kernel_language='Fortran', solver_type='classic', use_petsc=False,
     else:
         raise Exception('Unrecognized solver_type.')
 
-    x = pyclaw.Dimension('x', -1.0, 1.0, num_cells[0])
-    y = pyclaw.Dimension('y', -1.0, 1.0, num_cells[1])
-    z = pyclaw.Dimension('z', -1.0, 1.0, num_cells[2])
+    x = pyclaw.Dimension(-1.0, 1.0, num_cells[0], name='x')
+    y = pyclaw.Dimension(-1.0, 1.0, num_cells[1], name='y')
+    z = pyclaw.Dimension(-1.0, 1.0, num_cells[2], name='z')
     domain = pyclaw.Domain([x,y,z])
 
     state = pyclaw.State(domain,num_eqn)

--- a/examples/euler_3d/shock_bubble.py
+++ b/examples/euler_3d/shock_bubble.py
@@ -90,9 +90,9 @@ def setup(kernel_language='Fortran', solver_type='classic', use_petsc=False,
     else:
         raise Exception('Unrecognized solver_type.')
 
-    x = pyclaw.Dimension('x',  0.0, 2.0, num_cells[0])
-    y = pyclaw.Dimension('y',  0.0, 0.5, num_cells[1])
-    z = pyclaw.Dimension('z',  0.0, 0.5, num_cells[2])
+    x = pyclaw.Dimension(0.0, 2.0, num_cells[0], name='x')
+    y = pyclaw.Dimension(0.0, 0.5, num_cells[1], name='y')
+    z = pyclaw.Dimension(0.0, 0.5, num_cells[2], name='z')
     domain = pyclaw.Domain([x,y,z])
 
     solver.all_bcs = pyclaw.BC.extrap

--- a/examples/kpp/kpp.py
+++ b/examples/kpp/kpp.py
@@ -38,8 +38,8 @@ def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
 
     # Initialize domain
     mx=200; my=200
-    x = pyclaw.Dimension('x',-2.0,2.0,mx)
-    y = pyclaw.Dimension('y',-2.0,2.0,my)
+    x = pyclaw.Dimension(-2.0,2.0,mx,name='x')
+    y = pyclaw.Dimension(-2.0,2.0,my,name='y')
     domain = pyclaw.Domain([x,y])
     state = pyclaw.State(domain,solver.num_eqn)
 

--- a/examples/peano_shallow_2d/shallow2D.py
+++ b/examples/peano_shallow_2d/shallow2D.py
@@ -83,8 +83,8 @@ def shallow2D(use_petsc=False,outdir='./_output',solver_type='classic', disable_
     ylower = 0.0
     yupper = 1.0
     my = subdivisionFactor
-    x = pyclaw.Dimension('x',xlower,xupper,mx)
-    y = pyclaw.Dimension('y',ylower,yupper,my)
+    x = pyclaw.Dimension(xlower,xupper,mx,name='x')
+    y = pyclaw.Dimension(ylower,yupper,my,name='y')
     domain = geometry.Domain([x,y])
 
     num_eqn = 3  # Number of equations

--- a/examples/peano_shallow_2d/test_identical_grids.py
+++ b/examples/peano_shallow_2d/test_identical_grids.py
@@ -66,8 +66,8 @@ def test_3x3_grid():
     ylower = 0.0
     yupper = 1.0
     my = 3
-    x = pyclaw.Dimension('x',xlower,xupper,mx)
-    y = pyclaw.Dimension('y',ylower,yupper,my)
+    x = pyclaw.Dimension(xlower,xupper,mx,name='x')
+    y = pyclaw.Dimension(ylower,yupper,my,name='y')
     domain = pyclaw.Domain([x,y])
 
     num_eqn = 3  # Number of equations

--- a/examples/psystem_2d/psystem_2d.py
+++ b/examples/psystem_2d/psystem_2d.py
@@ -186,8 +186,8 @@ def setup(kernel_language='Fortran',
     restart_from_frame = None
 
     if restart_from_frame is None:
-        x = pyclaw.Dimension('x',x_lower,x_upper,mx)
-        y = pyclaw.Dimension('y',y_lower,y_upper,my)
+        x = pyclaw.Dimension(x_lower,x_upper,mx,name='x')
+        y = pyclaw.Dimension(y_lower,y_upper,my,name='y')
         domain = pyclaw.Domain([x,y])
         num_eqn = 3
         num_aux = 4

--- a/examples/shallow_1d/dam_break.py
+++ b/examples/shallow_1d/dam_break.py
@@ -45,7 +45,7 @@ def setup(use_petsc=False,kernel_language='Fortran',outdir='./_output',solver_ty
     xlower = -5.0
     xupper = 5.0
     mx = 500
-    x = pyclaw.Dimension('x',xlower,xupper,mx)
+    x = pyclaw.Dimension(xlower,xupper,mx,name='x')
     domain = pyclaw.Domain(x)
     state = pyclaw.State(domain,num_eqn)
 

--- a/examples/shallow_1d/sill.py
+++ b/examples/shallow_1d/sill.py
@@ -38,7 +38,7 @@ def setup(kernel_language='Python',use_petsc=False, outdir='./_output', solver_t
 
     xlower = -1.0
     xupper = 1.0
-    x = pyclaw.Dimension('x', xlower, xupper, 500)
+    x = pyclaw.Dimension( xlower, xupper, 500, name='x')
     domain = pyclaw.Domain(x)
     state = pyclaw.State(domain, 2, 1)
 

--- a/examples/shallow_2d/radial_dam_break.py
+++ b/examples/shallow_2d/radial_dam_break.py
@@ -56,8 +56,8 @@ def setup(use_petsc=False,outdir='./_output',solver_type='classic'):
     ylower = -2.5
     yupper = 2.5
     my = 150
-    x = pyclaw.Dimension('x',xlower,xupper,mx)
-    y = pyclaw.Dimension('y',ylower,yupper,my)
+    x = pyclaw.Dimension(xlower,xupper,mx,name='x')
+    y = pyclaw.Dimension(ylower,yupper,my,name='y')
     domain = pyclaw.Domain([x,y])
 
     state = pyclaw.State(domain,num_eqn)

--- a/examples/shallow_sphere/Rossby_wave.py
+++ b/examples/shallow_sphere/Rossby_wave.py
@@ -441,8 +441,8 @@ def setup(use_petsc=False,solver_type='classic',outdir='./_output', disable_outp
         raise ValueError(message)
 
 
-    x = pyclaw.Dimension('x',xlower,xupper,mx)
-    y = pyclaw.Dimension('y',ylower,yupper,my)
+    x = pyclaw.Dimension(xlower,xupper,mx,name='x')
+    y = pyclaw.Dimension(ylower,yupper,my,name='y')
     domain = pyclaw.Domain([x,y])
     dx = domain.grid.delta[0]
     dy = domain.grid.delta[1]
@@ -584,8 +584,8 @@ def plot_on_sphere():
         xupper = xlower + mx * dx
         yupper = ylower + my * dy
 
-        x = pyclaw.Dimension('x',xlower,xupper,mx)
-        y = pyclaw.Dimension('y',ylower,yupper,my)
+        x = pyclaw.Dimension(xlower,xupper,mx,name='x')
+        y = pyclaw.Dimension(ylower,yupper,my,name='y')
         patch = pyclaw.Patch([x,y])
 
 

--- a/examples/stegoton_1d/stegoton.py
+++ b/examples/stegoton_1d/stegoton.py
@@ -114,7 +114,7 @@ def setup(use_petsc=0,kernel_language='Fortran',solver_type='classic',outdir='./
 
     xlower=0.0; xupper=300.0
     cells_per_layer=12; mx=int(round(xupper-xlower))*cells_per_layer
-    x = pyclaw.Dimension('x',xlower,xupper,mx)
+    x = pyclaw.Dimension(xlower,xupper,mx,name='x')
     domain = pyclaw.Domain(x)
     state = pyclaw.State(domain,solver.num_eqn)
 

--- a/examples/traffic/traffic.py
+++ b/examples/traffic/traffic.py
@@ -28,7 +28,7 @@ def setup(use_petsc=0,outdir='./_output',solver_type='classic'):
     solver.bc_lower[0] = pyclaw.BC.extrap
     solver.bc_upper[0] = pyclaw.BC.extrap
 
-    x = pyclaw.Dimension('x',-1.0,1.0,500)
+    x = pyclaw.Dimension(-1.0,1.0,500,name='x')
     domain = pyclaw.Domain(x)
     num_eqn = 1
     state = pyclaw.State(domain,num_eqn)

--- a/src/pyclaw/geometry.py
+++ b/src/pyclaw/geometry.py
@@ -458,11 +458,13 @@ class Dimension(object):
     
     :Initialization:
     
-    Input:
-     - *name* - (string) string Name of dimension
+    Required arguments, order:
      - *lower* - (float) Lower extent of dimension
      - *upper* - (float) Upper extent of dimension
-     - *n* - (int) Number of cells
+     - *num_cells* - (int) Number of cells
+
+    Optional (keyword) arguments:
+     - *name* - (string) string Name of dimension
      - *units* - (string) Type of units, used for informational purposes only
        
     Output:
@@ -471,7 +473,7 @@ class Dimension(object):
     Example:
 
     >>> from clawpack.pyclaw.geometry import Dimension
-    >>> x = Dimension('x',0.,1.,100)
+    >>> x = Dimension(0.,1.,100,name='x')
     >>> print x
     Dimension x:  (num_cells,delta,[lower,upper]) = (100,0.01,[0.0,1.0])
     >>> x.name
@@ -573,6 +575,9 @@ class Dimension(object):
             self.upper = float(args[1])
             self.num_cells = int(args[2])
         elif isinstance(args[0],basestring):
+            import warnings
+            warnings.warn('Passing dimension name as first argument is deprecated. \
+                           Pass it as a keyword argument instead.')
             self.name = args[0]
             self.lower = float(args[1])
             self.upper = float(args[2])


### PR DESCRIPTION
As discussed in #480, this updates all examples to pass `name` as a keyword instead of first argument, and sends a deprecation warning if `name` is given as first argument.  This is fully backward-compatible, and is prelude to a backward-incompatible change (disallowing `name` as first argument).
