### PR TITLE
Copy grid.mapc2p in patch.deepcopy.

### DIFF
--- a/src/pyclaw/geometry.py
+++ b/src/pyclaw/geometry.py
@@ -725,6 +725,7 @@ class Patch(object):
         import copy
         result = self.__class__(copy.deepcopy(self.dimensions))
         result.__init__(copy.deepcopy(self.dimensions))
+        result.grid.mapc2p = self.grid.mapc2p
         
         for attr in ('level','patch_index'):
             setattr(result,attr,copy.deepcopy(getattr(self,attr)))


### PR DESCRIPTION
This fixes #495.  However, before merging it we should think which object should own the mapping.  Frankly, I cannot recall why we have both Grid and Patch; it seems that they serve exactly the same purpose.