### PR TITLE
point to correct doc location for new BC function signature.

### DIFF
--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -319,7 +319,7 @@ class Solver(object):
                                         function signature has been changed.
                                         The previous signature will not be
                                         supported in Clawpack 6.0.  Please see 
-                                        http://clawpack.github.io/doc/pyclaw/solvers.html 
+                                        http://www.clawpack.org/pyclaw/solvers.html#change-to-custom-bc-function-signatures
                                         for more information.""")
                     self._use_old_bc_sig = True
 


### PR DESCRIPTION
  Resolves https://github.com/clawpack/doc/issues/84.