### PR TITLE
Update to have the 'p' array written to the same file as 'q' and 'aux'

### DIFF
--- a/src/pyclaw/controller.py
+++ b/src/pyclaw/controller.py
@@ -71,10 +71,6 @@ class Controller(object):
         self.logger.handlers[1].setLevel(LOGGING_LEVELS[value])
 
     @property
-    def outdir_p(self):
-        r"""(string) - Directory to use for writing derived quantity files"""
-        return os.path.join(self.outdir,'_p')
-    @property
     def F_path(self):
         r"""(string) - Full path to output file for functionals"""
         return os.path.join(self.outdir,self.F_file_name+'.txt')
@@ -334,21 +330,18 @@ class Controller(object):
             if os.path.exists(self.outdir) and self.overwrite==False:
                 raise Exception("Refusing to overwrite existing output data. \
                  \nEither delete/move the directory or set controller.overwrite=True.")
-            if self.compute_p is not None:
+            write_p = False
+            if self.compute_p is not None and self.solution.state.mp > 0:
                 self.compute_p(self.solution.state)
-                self.solution.write(frame,self.outdir_p,
-                                        self.output_format,
-                                        self.file_prefix_p,
-                                        write_aux = False,
-                                        options = self.output_options,
-                                        write_p = True) 
+                write_p = True
 
             write_aux = (self.write_aux_always or self.write_aux_init)
             self.solution.write(frame,self.outdir,
                                         self.output_format,
                                         self.output_file_prefix,
                                         write_aux,
-                                        self.output_options)
+                                        self.output_options,
+                                        write_p)
 
         self.write_F('w')
 
@@ -367,20 +360,17 @@ class Controller(object):
                 # Save current solution to dictionary with frame as key
                 self.frames.append(copy.deepcopy(self.solution))
             if self.output_format is not None:
-                if self.compute_p is not None:
+                write_p = False
+                if self.compute_p is not None and self.solution.state.mp > 0:
                     self.compute_p(self.solution.state)
-                    self.solution.write(frame,self.outdir_p,
-                                            self.output_format,
-                                            self.file_prefix_p,
-                                            write_aux = False, 
-                                            options = self.output_options,
-                                            write_p = True) 
+                    write_p = True
                 
                 self.solution.write(frame,self.outdir,
                                             self.output_format,
                                             self.output_file_prefix,
                                             self.write_aux_always,
-                                            self.output_options)
+                                            self.output_options,
+                                            write_p)
             self.write_F()
 
             self.log_info("Solution %s computed for time t=%f"

--- a/src/pyclaw/io/ascii.py
+++ b/src/pyclaw/io/ascii.py
@@ -52,11 +52,15 @@ def write(solution,frame,path,file_prefix='fort',write_aux=False,
     with open(os.path.join(path,file_name),'w') as q_file:
         for state in solution.states:
             write_patch_header(q_file,state.patch)
-            if write_p:
-                q = state.p
-            else:
-                q = state.q
-            write_array(q_file, state.patch, q)
+            write_array(q_file, state.patch, state.q)
+
+    # Write fort.pxxxx file if required
+    if write_p:
+        file_name = 'fort.p%s' % str(frame).zfill(4)
+        with open(os.path.join(path,file_name),'w') as p_file:
+            for state in solution.states:
+                write_patch_header(p_file,state.patch)
+                write_array(p_file, state.patch, state.p)
 
     # Write fort.auxxxxx file if required
     if solution.num_aux > 0 and write_aux:

--- a/src/pyclaw/io/hdf5.py
+++ b/src/pyclaw/io/hdf5.py
@@ -128,11 +128,10 @@ def write(solution,frame,path,file_prefix='claw',write_aux=False,
                                 attr_name = '%s.%s' % (dim.name,attr)
                                 subgroup.attrs[attr_name] = getattr(dim,attr)
 
-                if write_p:
-                    q = state.p
-                else:
-                    q = state.q
+                q = state.q
                 subgroup.create_dataset('q',data=q,**options)
+                if write_p:
+                    subgroup.create_dataset('p',data=state.p,**options)
                 if write_aux and state.num_aux > 0:
                     subgroup.create_dataset('aux',data=state.aux,**options)
         


### PR DESCRIPTION
I was playing around with the option to have derived variables written out as described here: http://www.clawpack.org/pyclaw/classes.html#outputting-derived-quantities and noticed that it has two separate calls to the write function, which is different to how the 'aux' array is treated.  I decided to combine it all into one call, and make it such that when using the 'compute_p' option, it would add a new dataset to the hdf5 file, or in the ascii case create a file with the name 'fort.pxxxx' to make it consistent with writing out the aux array.

This seems cleaner, but maybe there are some other factors I missed?

I didn't look into 'binary.py' or 'netcdf.py' or into the 'petclaw' directory.  Also at first look, it does not look like the ability to read 'p' variables would be necessary?