### PR TITLE
Accumulate coverage on Travis across doctests and integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,16 @@ install:
 
 script:
   - cd pyclaw/src/pyclaw
-  - nosetests --first-pkg-wins --with-doctest --exclude=limiters --exclude=sharpclaw --exclude=io --exclude=example
+  - nosetests --first-pkg-wins --with-doctest --exclude=limiters --exclude=sharpclaw --exclude=io --exclude=example --with-coverage --cover-package=clawpack.pyclaw
+  - mv .coverage temp
   - if [[ "${TEST_PACKAGE}" == "pyclaw" ]]; then
         nosetests -v --first-pkg-wins --exclude=limiters --exclude=sharpclaw --exclude=io --with-coverage --cover-package=clawpack.pyclaw;
     fi
   - if [[ "${TEST_PACKAGE}" == "petclaw" ]]; then
        mpirun -n 4 nosetests -v --first-pkg-wins --exclude=limiters --exclude=sharpclaw --exclude=io;
     fi
+  - mv temp .coverage.doctest
+  - coverage combine
 
 after_success:
   - coveralls


### PR DESCRIPTION
Our doctests are not currently included in our test coverage reports.  This fixes that.