### PR TITLE
Enable plotting from PETSc output files with serial Solution object.

### DIFF
--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -349,6 +349,9 @@ class Solution(object):
             return io.ascii.read
         elif file_format in ('hdf','hdf5'):
             return io.hdf5.read
+        elif file_format == 'petsc':
+            from clawpack.petclaw import io
+            return io.petsc.read
         else:
             raise ValueError("File format %s not supported." % file_format)
 


### PR DESCRIPTION
This is needed because VisClaw always uses pyclaw.Solution rather
than petclaw.Solution.  An alternative fix would be to modify
VisClaw, but that seems unnecessary and more tightly coupled.