### PR TITLE
Encode strings for Python 3 when dealing with HDF5 files.

### DIFF
--- a/src/pyclaw/io/hdf5.py
+++ b/src/pyclaw/io/hdf5.py
@@ -120,7 +120,8 @@ def write(solution,frame,path,file_prefix='claw',write_aux=False,
                             subgroup.attrs[attr] = getattr(patch,attr)
 
                 # Add the dimension names as a attribute
-                subgroup.attrs['dimensions'] = patch.get_dim_attribute('name')
+                subgroup.attrs['dimensions'] = [name.encode('utf-8') 
+                            for name in patch.get_dim_attribute('name')]
                 # Dimension properties
                 for dim in patch.dimensions:
                     for attr in ['num_cells','lower','delta','upper',
@@ -172,7 +173,8 @@ def read(solution,frame,path='./',file_prefix='claw',read_aux=True,
             for patch in six.itervalues(f):
                 # Construct each dimension
                 dimensions = []
-                dim_names = patch.attrs['dimensions']
+                dim_names = [name.decode('ascii') 
+                        for name in patch.attrs['dimensions']]
                 for dim_name in dim_names:
                     dim = pyclaw.solution.Dimension(
                                         patch.attrs["%s.lower" % dim_name],


### PR DESCRIPTION
This incorporates part of https://github.com/clawpack/pyclaw/pull/553.