### PR TITLE
Fix some issues with examples.

### DIFF
--- a/examples/advection_2d_annulus/advection_annulus.py
+++ b/examples/advection_2d_annulus/advection_annulus.py
@@ -215,7 +215,7 @@ def setplot(plotdata):
     """ 
     Plot solution using VisClaw.
     """
-    from .mapc2p import mapc2p
+    from clawpack.pyclaw.examples.advection_2d_annulus.mapc2p import mapc2p
     import numpy as np
     from clawpack.visclaw import colormaps
 

--- a/examples/advection_reaction_2d/advection_reaction.py
+++ b/examples/advection_reaction_2d/advection_reaction.py
@@ -18,6 +18,25 @@ This example also shows how to use your own Riemann solver.
 
 from __future__ import absolute_import
 import numpy as np
+import os
+
+try:
+    from clawpack.pyclaw.examples.advection_reaction_2d import advection_2d
+except ImportError:
+    this_dir = os.path.dirname(__file__)
+    if this_dir == '':
+        this_dir = os.path.abspath('.')
+    import subprocess
+    cmd = "make -C "+this_dir
+    proc = subprocess.Popen("make -C "+this_dir+"/", shell=True, stdout = subprocess.PIPE)
+    proc.wait()
+    try:
+        # Now try to import again
+        from clawpack.pyclaw.examples.advection_reaction_2d import advection_2d
+    except ImportError:
+        raise
+
+
 
 t_period = 4.0
 epsilon = 0.1
@@ -47,7 +66,7 @@ def set_velocities(solver,state):
 
 def setup():
     from clawpack import pyclaw
-    import advection_2d
+    from clawpack.pyclaw.examples.advection_reaction_2d import advection_2d
 
     solver = pyclaw.ClawSolver2D(advection_2d)
     # Use dimensional splitting since no transverse solver is defined

--- a/examples/advection_reaction_2d/setup.py
+++ b/examples/advection_reaction_2d/setup.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# How to use this file
+# python setup.py build_ext -i
+
+from __future__ import absolute_import
+import os
+from os.path import join as pjoin
+from os.path import pardir as pardir
+
+def configuration(parent_package='',top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    config = Configuration('advection_reaction_2d', parent_package, top_path)
+
+    config.add_extension('advection_2d',
+                         ['rpn2_vc_advection_vector.f90', 'rpt2_dummy.f90'])
+
+
+    return config
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/examples/advection_reaction_2d/test_advection_reaction.py
+++ b/examples/advection_reaction_2d/test_advection_reaction.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 def test_advection_reaction():
     """ tests against expected sharpclaw results """
-    import advection_reaction
+    from clawpack.pyclaw.examples.advection_reaction_2d import advection_reaction
     from clawpack.pyclaw.util import test_app, check_diff
 
     def verify_advection_reaction(controller):

--- a/examples/euler_1d/Makefile
+++ b/examples/euler_1d/Makefile
@@ -5,18 +5,18 @@ SHARPCLAW = ../../src/pyclaw/sharpclaw
 ONE_D_SHARPCLAW_SOURCES = evec.f90 $(SHARPCLAW)/flux1.f90 $(SHARPCLAW)/ClawParams.f90 $(SHARPCLAW)/workspace.f90 $(SHARPCLAW)/weno.f90 $(SHARPCLAW)/reconstruct.f90
 
 all: 
-    make sharpclaw1.so
-    make euler_tfluct.so
+	make sharpclaw1.so
+	make euler_tfluct.so
 
 sharpclaw1.so: $(ONE_D_SHARPCLAW_SOURCES) 
-    ${F2PY} -m sharpclaw1 -c $(ONE_D_SHARPCLAW_SOURCES) 
+	${F2PY} -m sharpclaw1 -c $(ONE_D_SHARPCLAW_SOURCES) 
 
 euler_tfluct.so: euler_tfluct.f90
-    f2py -m $(basename $(notdir $@)) -c $^
+	f2py -m $(basename $(notdir $@)) -c $^
 
 clean:
-    rm -f *.o *.so *.pyc *.log
+	rm -f *.o *.so *.pyc *.log
 
 clobber: clean
-    rm -rf _output/
-    rm -rf _plots/
+	rm -rf _output/
+	rm -rf _plots/

--- a/examples/euler_1d/woodward_colella_blast.py
+++ b/examples/euler_1d/woodward_colella_blast.py
@@ -29,7 +29,7 @@ from clawpack.riemann.euler_with_efix_1D_constants import *
 
 # Compile Fortran code if not already compiled
 try:
-    from . import sharpclaw1
+    from clawpack.pyclaw.examples.euler_1d import sharpclaw1
 except ImportError:
     import os
     from clawpack.pyclaw.util import inplace_build
@@ -39,7 +39,7 @@ except ImportError:
     inplace_build(this_dir)
     try:
         # Now try to import again
-        from . import sharpclaw1
+        from clawpack.pyclaw.examples.euler_1d import sharpclaw1
     except ImportError:
         import logging
         logger = logging.getLogger()
@@ -69,7 +69,7 @@ def setup(use_petsc=False,outdir='./_output',solver_type='sharpclaw',kernel_lang
         solver.tfluct_solver = tfluct_solver
         if solver.tfluct_solver:
             try:
-                from . import euler_tfluct
+                from clawpack.pyclaw.examples.euler_1d import euler_tfluct
                 solver.tfluct = euler_tfluct
             except ImportError:
                 import logging
@@ -80,7 +80,7 @@ def setup(use_petsc=False,outdir='./_output',solver_type='sharpclaw',kernel_lang
         solver.lim_type = 1
         solver.char_decomp = 2
         try:
-            from . import sharpclaw1
+            from clawpack.pyclaw.examples.euler_1d import sharpclaw1
             solver.fmod = sharpclaw1
         except ImportError:
             pass

--- a/examples/euler_2d/shock_forward_step.py
+++ b/examples/euler_2d/shock_forward_step.py
@@ -29,7 +29,26 @@ aligned with the grid.
 
 from __future__ import absolute_import
 from six.moves import range
+import os
+
 gamma = 1.4 # Ratio of specific heats
+
+try:
+    from clawpack.pyclaw.examples.euler_2d import euler_with_boundaries
+except ImportError:
+    this_dir = os.path.dirname(__file__)
+    if this_dir == '':
+        this_dir = os.path.abspath('.')
+    import subprocess
+    cmd = "make -C "+this_dir
+    proc = subprocess.Popen("make -C "+this_dir+"/", shell=True, stdout = subprocess.PIPE)#, stdout=subprocess.PIPE)
+    proc.wait()
+    try:
+        # Now try to import again
+        from clawpack.pyclaw.examples.euler_2d import euler_with_boundaries
+    except ImportError:
+        raise
+
 
 def incoming_shock(state,dim,t,qbc,num_ghost):
     """
@@ -56,10 +75,7 @@ def setup(use_petsc=False,solver_type='classic', outdir='_output', kernel_langua
     else:
         from clawpack import pyclaw
 
-    try:
-        import euler_with_boundaries
-    except ImportError:
-        raise Exception("Please run make in this directory to compile the Riemann solver.")
+    import euler_with_boundaries
 
     if solver_type=='sharpclaw':
         #solver = pyclaw.SharpClawSolver2D(euler_with_boundaries)

--- a/examples/kpp/kpp.py
+++ b/examples/kpp/kpp.py
@@ -76,7 +76,7 @@ def setplot(plotdata):
     # Set up for axes in this figure:
     plotaxes = plotfigure.new_plotaxes()
     plotaxes.title = 'q[0]'
-    plotaxes.afteraxes = "pylab.axis('scaled')" 
+    plotaxes.afteraxes = "plt.axis('scaled')"
 
     # Set up for item on these axes:
     plotitem = plotaxes.new_plotitem(plot_type='2d_pcolor')
@@ -92,7 +92,7 @@ def setplot(plotdata):
     # Set up for axes in this figure:
     plotaxes = plotfigure.new_plotaxes()
     plotaxes.title = 'q[0]'
-    plotaxes.afteraxes = "pylab.axis('scaled')" 
+    plotaxes.afteraxes = "plt.axis('scaled')"
 
     # Set up for item on these axes:
     plotitem = plotaxes.new_plotitem(plot_type='2d_contour')

--- a/examples/psystem_2d/psystem_2d.py
+++ b/examples/psystem_2d/psystem_2d.py
@@ -260,7 +260,6 @@ def setplot(plotdata):
 
 def stress(current_data):    
     import numpy as np
-    from .psystem_2d import setaux
     aux = setaux(current_data.x[:,0],current_data.y[0,:])
     q = current_data.q
     return np.exp(aux[1,...]*q[0,...])-1.

--- a/examples/shallow_sphere/Rossby_wave.py
+++ b/examples/shallow_sphere/Rossby_wave.py
@@ -28,8 +28,8 @@ from clawpack.pyclaw.util import inplace_build
 from six.moves import range
 
 try:
-    from . import problem
-    from . import classic2
+    from clawpack.pyclaw.examples.shallow_sphere import problem
+    from clawpack.pyclaw.examples.shallow_sphere import classic2
 
 except ImportError:
     this_dir = os.path.dirname(__file__)
@@ -39,8 +39,8 @@ except ImportError:
 
     try:
         # Now try to import again
-        from . import problem
-        from . import classic2
+        from clawpack.pyclaw.examples.shallow_sphere import problem
+        from clawpack.pyclaw.examples.shallow_sphere import classic2
     except ImportError:
         print("***\nUnable to import problem module or automatically build, try running (in the directory of this file):\n python setup.py build_ext -i\n***", file=sys.stderr)
         raise

--- a/examples/stegoton_1d/stegoton.py
+++ b/examples/stegoton_1d/stegoton.py
@@ -206,14 +206,12 @@ def setplot(plotdata):
  
 def velocity(current_data):
     """Compute velocity from strain and momentum"""
-    from .stegoton import setaux
     aux=setaux(current_data.x,rhoB=4,KB=4)
     velocity = current_data.q[1,:]/aux[0,:]
     return velocity
 
 def stress(current_data):
     """Compute stress from strain and momentum"""
-    from .stegoton import setaux
     from clawpack.riemann.nonlinear_elasticity_1D_py import sigma 
     aux=setaux(current_data.x)
     epsilon = current_data.q[0,:]


### PR DESCRIPTION
1. Automatically compile things (by calling Make) where necessary.
2. Use absolute imports for Python 3 compatibility.

Also some miscellaneous fixes, like replacing spaces with tabs in a makefile.

This avoids some errors that can appear when building the gallery, as noted by @rjleveque .