### PR TITLE
Use conda to build on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: python
+
+os: linux
+
 env:
   - TEST_PACKAGE="pyclaw"
   - TEST_PACKAGE="petclaw"
+
 python:
   - 2.7
   - 3.5
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq gfortran liblapack-pic
@@ -15,15 +20,29 @@ before_install:
   - git submodule update clawutil visclaw riemann
   - rm -rf pyclaw
   - ln -s ../ pyclaw
+
 install:
-  - export CLAWPACK=`pwd`
-  - bash ../.travis_build_stack.sh;
-  - export PATH=${CLAWPACK}/stack/bin:${PATH};
-# it would be better to get coverage/python-coveralls into hashstack eventually, but this works
-  - easy_install pip
-  - pip install coverage
-  - pip install python-coveralls
-  - python setup.py install;
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no --set show_channel_urls yes
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - conda install -c conda-forge mpich mpi4py
+  - conda install matplotlib nose coverage
+  - conda install -c clawpack hdf5-parallel
+  - conda install -c clawpack h5py-parallel
+  - conda install -c conda-forge petsc4py
+  - conda install -c conda-forge scipy=0.17.1
+  - conda install -c conda-forge python-coveralls
+  - python -c "import scipy; print(scipy.__version__)"
+  - python setup.py install
 
 script:
   - cd pyclaw/src/pyclaw

--- a/src/petclaw/io/hdf5.py
+++ b/src/petclaw/io/hdf5.py
@@ -111,7 +111,8 @@ def write(solution,frame,path,file_prefix='claw',write_aux=False,
                         subgroup.attrs[attr] = getattr(patch,attr)
 
             # Add the dimension names as a attribute
-            subgroup.attrs['dimensions'] = patch.get_dim_attribute('name')
+            subgroup.attrs['dimensions'] = [ name.encode('utf-8')
+                        for name in patch.get_dim_attribute('name') ]
             # Dimension properties
             for dim in patch.dimensions:
                 for attr in ['num_cells','lower','delta','upper',
@@ -164,7 +165,8 @@ def read(solution,frame,path='./',file_prefix='claw',read_aux=True,
         for patch in six.itervalues(f):
             # Construct each dimension
             dimensions = []
-            dim_names = patch.attrs['dimensions']
+            dim_names = [ name.decode('ascii')
+                          for name in patch.attrs['dimensions'] ]
             for dim_name in dim_names:
                 dim = geometry.Dimension(
                     patch.attrs["%s.lower" % dim_name],

--- a/src/pyclaw/io/hdf5.py
+++ b/src/pyclaw/io/hdf5.py
@@ -173,8 +173,8 @@ def read(solution,frame,path='./',file_prefix='claw',read_aux=True,
             for patch in six.itervalues(f):
                 # Construct each dimension
                 dimensions = []
-                dim_names = [name.decode('ascii') 
-                        for name in patch.attrs['dimensions']]
+                dim_names = [ name.decode('ascii')
+                              for name in patch.attrs['dimensions'] ]
                 for dim_name in dim_names:
                     dim = pyclaw.solution.Dimension(
                                         patch.attrs["%s.lower" % dim_name],


### PR DESCRIPTION
Thanks to Lisandro Dalcin for helping iron this out.

I have set up a [Clawpack organization on Anaconda.org](https://anaconda.org/Clawpack) to host recipes for the two packages that were most problematic (hdf5 and h5py with parallel support).

It might be worth setting up a conda recipe for Clawpack itself on OS X and Linux, which would avoid the need for users to compile the Fortran code in pyclaw and riemann.

This PR replaces #557; it has cleaner history.