### PR TITLE
Better error message when initializing State with invalid num_eqn or num_aux.

### DIFF
--- a/src/pyclaw/state.py
+++ b/src/pyclaw/state.py
@@ -131,6 +131,10 @@ class State(object):
         else:
             raise Exception("""A PyClaw State object must be initialized with
                              a PyClaw Patch object.""")
+        if not isinstance(num_eqn,int):
+            raise Exception("State must be initialized with num_eqn set to a positive integer")
+        if not isinstance(num_aux,int):
+            raise Exception("State must be initialized with num_aux set to a non-negative integer")
 
         # ========== Attribute Definitions ===================================
         r"""pyclaw.Patch.patch - The patch this state lives on"""


### PR DESCRIPTION
This can happen for instance if you switch to another Riemann solver
and solver.num_eqn is not set (it will be None).
Previously, in this situation the code continued to an obscure point and raised
a seemingly unrelated exception.