### PR TITLE
Make plots.py work with Python 3.

### DIFF
--- a/src/pyclaw/plot.py
+++ b/src/pyclaw/plot.py
@@ -13,7 +13,7 @@ def plot(setplot=None, outdir="./_output", plotdir=None, htmlplot=False,
     # Construct a plot directory if not provided
     if plotdir is None:
         try: 
-            plotdir = os.path.join(os.path.split(outdir)[:-2],"_plots")
+            plotdir = os.path.join(outdir,"../_plots")
         except AttributeError:
             plotdir = os.path.join(os.getcwd(),"_plots")
     


### PR DESCRIPTION
The method `os.path.join` changed in Python 3 in a way that broke a line of pyclaw/plot.py.  This was only activated when generating html plots, which is why I didn't see it until now.  We have no tests that generate html plots, currently.

This PR fixes the line in question.