### PR TITLE
Catch wrong format errors

### DIFF
--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -336,7 +336,7 @@ def read_array(f, state, num_var):
                 while len(l)<num_var:
                     line = f.readline()
                     if line=='':
-                        raise IOError('Unexpected EOF')
+                        raise IOError('Unexpected EOF in %s' % f.name)
                     l = l + line.split()
                 for m in range(num_var):
                     q[m,i] = float(l[m])
@@ -347,7 +347,7 @@ def read_array(f, state, num_var):
                     while len(l)<num_var:
                         line = f.readline()
                         if line=='':
-                            raise IOError('Unexpected EOF')
+                            raise IOError('Unexpected EOF in %s' % f.name)
                         l = l + line.split()
                     for m in range(num_var):
                         q[m,i,j] = float(l[m])
@@ -360,7 +360,7 @@ def read_array(f, state, num_var):
                         while len(l) < num_var:
                             line = f.readline()
                             if line=='':
-                                raise IOError('Unexpected EOF')
+                                raise IOError('Unexpected EOF in %s' % f.name)
                             l = l + line.split()
                         for m in range(num_var):
                             q[m,i,j,k] = float(l[m])

--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -335,7 +335,7 @@ def read_array(f, state, num_var):
                 l = []
                 while len(l)<num_var:
                     line = f.readline()
-                    if line=='':
+                    if line == '':
                         raise IOError('Unexpected EOF in %s' % f.name)
                     l = l + line.split()
                 for m in range(num_var):
@@ -344,9 +344,9 @@ def read_array(f, state, num_var):
             for j in range(patch.dimensions[1].num_cells):
                 for i in range(patch.dimensions[0].num_cells):
                     l = []
-                    while len(l)<num_var:
+                    while len(l) < num_var:
                         line = f.readline()
-                        if line=='':
+                        if line == '':
                             raise IOError('Unexpected EOF in %s' % f.name)
                         l = l + line.split()
                     for m in range(num_var):
@@ -359,7 +359,7 @@ def read_array(f, state, num_var):
                         l=[]
                         while len(l) < num_var:
                             line = f.readline()
-                            if line=='':
+                            if line == '':
                                 raise IOError('Unexpected EOF in %s' % f.name)
                             l = l + line.split()
                         for m in range(num_var):

--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -329,39 +329,46 @@ def read_array(f, state, num_var):
     q = np.zeros(q_shape)
 
 
-    if patch.num_dim == 1:
-        for i in range(patch.dimensions[0].num_cells):
-            l = []
-            while len(l)<num_var:
-                line = f.readline()
-                l = l + line.split()
-            for m in range(num_var):
-                q[m,i] = float(l[m])
-    elif patch.num_dim == 2:
-        for j in range(patch.dimensions[1].num_cells):
+    try:
+        if patch.num_dim == 1:
             for i in range(patch.dimensions[0].num_cells):
                 l = []
                 while len(l)<num_var:
                     line = f.readline()
                     l = l + line.split()
                 for m in range(num_var):
-                    q[m,i,j] = float(l[m])
-            blank = f.readline()
-    elif patch.num_dim == 3:
-        for k in range(patch.dimensions[2].num_cells):
+                    q[m,i] = float(l[m])
+        elif patch.num_dim == 2:
             for j in range(patch.dimensions[1].num_cells):
                 for i in range(patch.dimensions[0].num_cells):
-                    l=[]
-                    while len(l) < num_var:
+                    l = []
+                    while len(l)<num_var:
                         line = f.readline()
                         l = l + line.split()
                     for m in range(num_var):
-                        q[m,i,j,k] = float(l[m])
+                        q[m,i,j] = float(l[m])
                 blank = f.readline()
-            blank = f.readline()
-    else:
-        msg = "Read only supported up to 3d."
+        elif patch.num_dim == 3:
+            for k in range(patch.dimensions[2].num_cells):
+                for j in range(patch.dimensions[1].num_cells):
+                    for i in range(patch.dimensions[0].num_cells):
+                        l=[]
+                        while len(l) < num_var:
+                            line = f.readline()
+                            l = l + line.split()
+                        for m in range(num_var):
+                            q[m,i,j,k] = float(l[m])
+                    blank = f.readline()
+                blank = f.readline()
+        else:
+            msg = "Read only supported up to 3d."
+            logger.critical(msg)
+            raise Exception(msg)
+    except:
+        msg = '*** Problem reading patch data'
+        if l[m] == 'grid_number':
+            msg = msg + '\n*** Format might be binary, is plotdata.format set properly?'
         logger.critical(msg)
-        raise Exception(msg)
+        raise IOError(msg)
 
     return q

--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -335,6 +335,8 @@ def read_array(f, state, num_var):
                 l = []
                 while len(l)<num_var:
                     line = f.readline()
+                    if line=='':
+                        raise IOError('Unexpected EOF')
                     l = l + line.split()
                 for m in range(num_var):
                     q[m,i] = float(l[m])
@@ -344,6 +346,8 @@ def read_array(f, state, num_var):
                     l = []
                     while len(l)<num_var:
                         line = f.readline()
+                        if line=='':
+                            raise IOError('Unexpected EOF')
                         l = l + line.split()
                     for m in range(num_var):
                         q[m,i,j] = float(l[m])
@@ -355,6 +359,8 @@ def read_array(f, state, num_var):
                         l=[]
                         while len(l) < num_var:
                             line = f.readline()
+                            if line=='':
+                                raise IOError('Unexpected EOF')
                             l = l + line.split()
                         for m in range(num_var):
                             q[m,i,j,k] = float(l[m])
@@ -366,8 +372,7 @@ def read_array(f, state, num_var):
             raise Exception(msg)
     except:
         msg = '*** Problem reading patch data'
-        if l[m] == 'grid_number':
-            msg = msg + '\n*** Format might be binary, is plotdata.format set properly?'
+        msg = msg + '\n*** Format might be binary, is plotdata.format set properly?'
         logger.critical(msg)
         raise IOError(msg)
 

--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -569,14 +569,11 @@ def read_data_line(inputfile,num_entries=1,data_type=float):
 
     """
     l = []
-    count = 0
     while  l==[]:  # skip over blank lines
         line = inputfile.readline()
+        if line == '':
+            raise IOError('*** Reached EOF in file %s' % inputfile)
         l = line.split()
-        count += 1
-        if count>100:
-            print('*** Infinite loop??')
-            raise IOError('*** Infinite loop?? inputfile = %s' % inputfile)
     if num_entries == 1:  # This is a convenience for calling functions
         return data_type(l[0])
     val = np.empty(num_entries,data_type)

--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -569,9 +569,14 @@ def read_data_line(inputfile,num_entries=1,data_type=float):
 
     """
     l = []
+    count = 0
     while  l==[]:  # skip over blank lines
         line = inputfile.readline()
         l = line.split()
+        count += 1
+        if count>100:
+            print('*** Infinite loop??')
+            raise IOError('*** Infinite loop?? inputfile = %s' % inputfile)
     if num_entries == 1:  # This is a convenience for calling functions
         return data_type(l[0])
     val = np.empty(num_entries,data_type)

--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -572,7 +572,7 @@ def read_data_line(inputfile,num_entries=1,data_type=float):
     while  l==[]:  # skip over blank lines
         line = inputfile.readline()
         if line == '':
-            raise IOError('*** Reached EOF in file %s' % inputfile)
+            raise IOError('*** Reached EOF in file %s' % inputfile.name)
         l = line.split()
     if num_entries == 1:  # This is a convenience for calling functions
         return data_type(l[0])


### PR DESCRIPTION
If `plotdata.format = "ascii"` in `setplot.py` but the output is actually binary then the plotting routine generally hangs in an infinite loop.  This is because `f.readline()` is called in a `while` loop to read all the data from a `fort.q` file but the data isn't there, and `readline` does not raise an exception at the end of the file, it just returns the empty string over and over.

In some cases, instead of an infinite loop it died when trying to convert `grid_number` into a float (reading the next header when it thought it was reading data).

Both of these problems should now be caught with an error message suggesting the output might be binary.

I also fixed a potential similar infinite loop problem in `util.py`.