### PR TITLE
forestclaw/ascii.py should import forestclaw

### DIFF
--- a/src/forestclaw/fileio/ascii.py
+++ b/src/forestclaw/fileio/ascii.py
@@ -9,11 +9,15 @@ from __future__ import print_function
 
 import logging
 import numpy as np
+# import clawpack.forestclaw as forestclaw
 
 from .. import Dimension, Patch
 from clawpack.pyclaw.fileio.ascii import write
 from clawpack.pyclaw.fileio.ascii import read
 from clawpack.pyclaw.util import read_data_line
+import forestclaw
+
+
 
 logger = logging.getLogger('pyclaw.fileio')
 


### PR DESCRIPTION
It isn't clear why this code was working without the explicit import of forestclaw.  But it is in there now, and so things work (so far).