### PR TITLE
change import forestclaw to import clawpack.forestclaw

### DIFF
--- a/src/forestclaw/fileio/ascii.py
+++ b/src/forestclaw/fileio/ascii.py
@@ -15,7 +15,7 @@ from .. import Dimension, Patch
 from clawpack.pyclaw.fileio.ascii import write
 from clawpack.pyclaw.fileio.ascii import read
 from clawpack.pyclaw.util import read_data_line
-import forestclaw
+import clawpack.forestclaw as forestclaw
 
 
 

--- a/src/forestclaw/fileio/ascii.py
+++ b/src/forestclaw/fileio/ascii.py
@@ -9,13 +9,12 @@ from __future__ import print_function
 
 import logging
 import numpy as np
-# import clawpack.forestclaw as forestclaw
+from clawpack import forestclaw
 
 from .. import Dimension, Patch
 from clawpack.pyclaw.fileio.ascii import write
 from clawpack.pyclaw.fileio.ascii import read
 from clawpack.pyclaw.util import read_data_line
-import clawpack.forestclaw as forestclaw
 
 
 


### PR DESCRIPTION
I would like to use this PR as a discussion. I can't `import xxxclaw` but only `import clawpack.xxxclaw`. Changing this line of code makes it work for me. I am not sure whether not being able to `import xxxclaw` is normal. But I do see a lot of `import clawpack.xxxclaw as xxxclaw` in pyclaw source code. 