### PR TITLE
Fix forestclaw import

### DIFF
--- a/src/forestclaw/fileio/ascii.py
+++ b/src/forestclaw/fileio/ascii.py
@@ -10,12 +10,12 @@ from __future__ import print_function
 import logging
 import numpy as np
 # import clawpack.forestclaw as forestclaw
+from clawpack import forestclaw
 
 from .. import Dimension, Patch
 from clawpack.pyclaw.fileio.ascii import write
 from clawpack.pyclaw.fileio.ascii import read
 from clawpack.pyclaw.util import read_data_line
-import forestclaw
 
 
 


### PR DESCRIPTION
This is a second attempt to merge this fix.  See [this PR](https://github.com/clawpack/pyclaw/pull/602)