### PR TITLE
Remove distutils registration of non-existent forestclaw subpackages.

### DIFF
--- a/src/forestclaw/setup.py
+++ b/src/forestclaw/setup.py
@@ -5,10 +5,6 @@ def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
 
     config = Configuration('forestclaw', parent_package, top_path)
-    config.add_data_files('log.config')
-    config.add_subpackage('classic')
-    config.add_subpackage('sharpclaw')
-    config.add_subpackage('limiters')
     config.add_subpackage('fileio')
     return config
 


### PR DESCRIPTION
Currently this setup.py file doesn't actually get used (I think).  But we may use it soon (see https://github.com/clawpack/clawpack/pull/136) and it shouldn't be setting up these subpackages that don't exist (and don't need to exist).