### PR TITLE
Properly initialize GaugeSolution if gauge has only one reading.

### DIFF
--- a/src/pyclaw/gauges.py
+++ b/src/pyclaw/gauges.py
@@ -135,6 +135,8 @@ class GaugeSolution(object):
             self.q = pandas.DataFrame()
         else:
             data = numpy.loadtxt(gauge_path, comments="#")
+            if len(x.shape) == 1:
+                x = np.array([x])
             self.level = data[:, 0].astype(numpy.int64)
             self.t = data[:, 1]
             self.q = data[:, 2:].transpose()


### PR DESCRIPTION
This is a simple fix to resolve https://github.com/clawpack/visclaw/issues/172 by making the resulting array 2-dimensional even if the gauge file only has one line.