### PR TITLE
Bug Fix on Capacity Array

### DIFF
--- a/src/pyclaw/classic/solver.py
+++ b/src/pyclaw/classic/solver.py
@@ -314,7 +314,7 @@ class ClawSolver1D(ClawSolver):
 
             # Find local value for dt/dx
             if state.index_capa>=0:
-                dtdx = self.dt / (grid.delta[0] * state.aux[state.index_capa,:])
+                dtdx = self.dt / (grid.delta[0] * aux[state.index_capa,:])
             else:
                 dtdx += self.dt/grid.delta[0]
         


### PR DESCRIPTION
Use auxbc instead of state.aux when state.index_capa>=0. Dimension matches.
Check can be performed on Pyclaw example advection_1d by adding aux to introduce nonuniform cells.