### PR TITLE
Make Travis run our examples as tests again.

### DIFF
--- a/run_tests_on_travis.sh
+++ b/run_tests_on_travis.sh
@@ -11,19 +11,23 @@ cd src/pyclaw
 if [ "${TEST_PACKAGE}" == "pyclaw" ]; then
     # pyclaw doc-tests
     nosetests --first-pkg-wins --with-doctest --exclude=limiters --exclude=sharpclaw --exclude=fileio --exclude=example --with-coverage --cover-package=clawpack.pyclaw;
-    mv .coverage temp;
+    mv .coverage .coverage.doctest;
     # pyclaw examples and I/O tests
     nosetests -v --first-pkg-wins --exclude=limiters --exclude=sharpclaw --with-coverage --cover-package=clawpack.pyclaw --include=IOTest;
-    mv temp .coverage.doctest;
+    cd ../../examples;
+    nosetests -v --with-coverage --cover-package=clawpack.pyclaw;
+    mv .coverage ../src/pyclaw/.coverage.examples;
+    cd ../src/pyclaw;
     coverage combine;
 fi
 
 if [[ "${TEST_PACKAGE}" == "petclaw" ]]; then
-    # petclaw examples
-    mpirun -n 4 nosetests -v --first-pkg-wins --exclude=limiters --exclude=sharpclaw --exclude=fileio;
-    cd ../petclaw/tests;
     # petclaw I/O tests
+    cd ../petclaw/tests;
     mpirun -n 4 nosetests -v --first-pkg-wins --include=IOTest;
+    # petclaw examples
+    cd ../../../examples;
+    mpirun -n 4 nosetests -v --first-pkg-wins;
 fi
 
 if [[ "${TEST_PACKAGE}" == "forestclaw" ]]; then


### PR DESCRIPTION
This was accidentally disabled when we removed the soft link
from src to examples.  Since then the tests haven't been running.