### PR TITLE
add cubic flux example and test

### DIFF
--- a/examples/cubic_1d/cubic.py
+++ b/examples/cubic_1d/cubic.py
@@ -33,6 +33,9 @@ def setup(use_petsc=0, outdir='./_output', solver_type='classic', weno_order=5, 
         solver = pyclaw.ClawSolver1D(riemann_solver)
         solver.limiters = pyclaw.limiters.tvd.vanleer
 
+    solver.cfl_max = 1.0
+    solver.cfl_desired = 0.5
+
     solver.kernel_language = 'Fortran'
 
     solver.bc_lower[0] = pyclaw.BC.extrap

--- a/examples/cubic_1d/cubic.py
+++ b/examples/cubic_1d/cubic.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+r"""
+Cubic equation
+=========================
+
+Solve the cubic conservation law:
+
+.. math::
+    q_t + (q^3)_x = 0.
+
+This is a scalar nonlinear conservation law which is often used as a simple
+example for problems with non-convex flux functions.
+"""
+from __future__ import absolute_import
+import numpy as np
+from clawpack import riemann
+
+def setup(use_petsc=0, outdir='./_output', solver_type='classic', weno_order=5, N=1000):
+
+    if use_petsc:
+        import clawpack.petclaw as pyclaw
+    else:
+        from clawpack import pyclaw
+
+    riemann_solver = riemann.cubic_1D
+
+    if solver_type=='sharpclaw':
+        solver = pyclaw.SharpClawSolver1D(riemann_solver)
+        solver.weno_order = weno_order
+    else:
+        solver = pyclaw.ClawSolver1D(riemann_solver)
+        solver.limiters = pyclaw.limiters.tvd.vanleer
+
+    solver.kernel_language = 'Fortran'
+
+    solver.bc_lower[0] = pyclaw.BC.extrap
+    solver.bc_upper[0] = pyclaw.BC.extrap
+
+    x = pyclaw.Dimension(-1.0, 3.0, N, name='x')
+    domain = pyclaw.Domain(x)
+    num_eqn = 1
+    state = pyclaw.State(domain, num_eqn)
+
+    xc = state.grid.x.centers
+    qL = 4.0
+    qR = -2.0
+    state.q[0,:] = (xc < -0.5) * qL + (xc >= -0.5) * qR
+
+    claw = pyclaw.Controller()
+    claw.tfinal = 0.2
+    claw.solution = pyclaw.Solution(state, domain)
+    claw.solver = solver
+    claw.outdir = outdir
+    claw.setplot = setplot
+    claw.keep_copy = True
+
+    return claw
+
+
+def setplot(plotdata):
+    """
+    Plot solution using VisClaw.
+    """
+    plotdata.clearfigures()  # clear any old figures,axes,items data
+
+    # Figure for q[0]
+    plotfigure = plotdata.new_plotfigure(name='q[0]', figno=0)
+
+    # Set up for axes in this figure:
+    plotaxes = plotfigure.new_plotaxes()
+    plotaxes.xlimits = 'auto'
+    plotaxes.ylimits = 'auto'
+    plotaxes.title = 'q[0]'
+
+    # Set up for item on these axes:
+    plotitem = plotaxes.new_plotitem(plot_type='1d')
+    plotitem.plot_var = 0
+    plotitem.plotstyle = '-o'
+    plotitem.color = 'b'
+
+    return plotdata
+
+
+if __name__=="__main__":
+    # Run the example from the command line.
+    # You can use the usual options, e.g. `iplot=1` to plot
+    # the numerical solution.
+    from clawpack.pyclaw.util import run_app_from_main
+    output = run_app_from_main(setup, setplot)

--- a/examples/cubic_1d/test_cubic.py
+++ b/examples/cubic_1d/test_cubic.py
@@ -1,0 +1,27 @@
+"Runs the test problem."
+from __future__ import absolute_import
+
+def test_cubic():
+    import numpy as np
+    import cubic
+
+    claw = cubic.setup(solver_type="sharpclaw")
+    # For the classic solver with solver.limiters = pyclaw.limiters.tvd.vanleer,
+    # nonclassical solutions occur...
+    claw.run()
+    sol = claw.solution.state.get_q_global()
+
+    if sol is not None:
+        xc = claw.solution.state.grid.x.centers
+        qL = 4.0
+        qR = -2.0
+        x0 = -0.5 + (qL**3 - qR**3) / (qL - qR) * 0.2
+        expected_sol = (xc < x0) * qL + (xc >= x0) * qR
+        test_err = np.linalg.norm(expected_sol - sol, ord=1) / len(xc)
+        print(test_err)
+        assert test_err < 1.e-3
+
+
+if __name__=="__main__":
+    import nose
+    nose.main()

--- a/examples/cubic_1d/test_cubic.py
+++ b/examples/cubic_1d/test_cubic.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 def test_cubic():
     import numpy as np
-    import cubic
+    from . import cubic
 
     claw = cubic.setup(solver_type="sharpclaw")
     # For the classic solver with solver.limiters = pyclaw.limiters.tvd.vanleer,


### PR DESCRIPTION
This is a regression test for the RIemann solver for the scalar conservation law with cubic flux added in https://github.com/clawpack/riemann/pull/158.
Note: This PR and the PR https://github.com/clawpack/riemann/pull/158 should be reviewed carefully to check whether I did something stupid. For the test case used here, I get a nonclassical (non-TVD) shock when I use `solver_type='classic'` and `solver.limiters = pyclaw.limiters.tvd.vanleer`, which I didn't expect. For the standard sharpclaw solvers, the usual entropy solution appears.