### PR TITLE
Logging config: Don't disable existing loggers

### DIFF
--- a/src/pyclaw/__init__.py
+++ b/src/pyclaw/__init__.py
@@ -16,7 +16,7 @@ _DEFAULT_LOG_CONFIG_PATH = os.path.join(os.path.dirname(__file__),'log.config')
 del os
 
 # Setup loggers
-logging.config.fileConfig(_DEFAULT_LOG_CONFIG_PATH)
+logging.config.fileConfig(_DEFAULT_LOG_CONFIG_PATH, disable_existing_loggers=False)
 
 __all__ = []
 


### PR DESCRIPTION
When importing pyclaw from another package, all of the other package's loggers are disabled. This can be avoided by using the option `disable_existing_loggers` when loading file config: https://docs.python.org/3/library/logging.config.html#logging.config.fileConfig