### PR TITLE
allow for str or bytes for h5py dimension names

### DIFF
--- a/src/pyclaw/fileio/hdf5.py
+++ b/src/pyclaw/fileio/hdf5.py
@@ -21,6 +21,7 @@ import logging
 
 from clawpack import pyclaw
 import six
+import numpy as np
 
 logger = logging.getLogger('pyclaw.fileio')
 
@@ -173,8 +174,7 @@ def read(solution,frame,path='./',file_prefix='claw',read_aux=True,
             for patch in six.itervalues(f):
                 # Construct each dimension
                 dimensions = []
-                dim_names = [ name.decode('ascii')
-                              for name in patch.attrs['dimensions'] ]
+                dim_names = np.array(patch.attrs["dimensions"]).astype(str)
                 for dim_name in dim_names:
                     dim = pyclaw.solution.Dimension(
                                         patch.attrs["%s.lower" % dim_name],


### PR DESCRIPTION
I'm not sure what changed, but my euler_3d test is giving an error now b/c one of the two files being read here has string type for its dimensions. This handles that case and the test error is resolved. If there is a deeper reason that should be figured out as to why some of these files are giving encoded strings and some are not, then maybe worth diving into that before merging.