### PR TITLE
Corrections to 1D variable-coefficient non-conservative advection example

### DIFF
--- a/examples/advection_1d_variable/variable_coefficient_advection.py
+++ b/examples/advection_1d_variable/variable_coefficient_advection.py
@@ -4,11 +4,12 @@ r"""
 One-dimensional advection with variable velocity
 ================================================
 
-Solve the conservative variable-coefficient advection equation:
+Solve the non-conservative variable-coefficient advection equation
+(also known as the color equation):
 
-.. math:: q_t + (u(x)q)_x = 0.
+.. math:: q_t + u(x) q_x = 0.
 
-Here q is the density of some conserved quantity and u(x) is the velocity.
+Here q is the density of some quantity and u(x) is the velocity.
 The velocity field used is
 
 .. math:: u(x) = 2 + sin(2\pi x).
@@ -60,12 +61,12 @@ def setup(use_petsc=False,solver_type='classic',kernel_language='Python',outdir=
 
     if solver_type=='classic':
         if kernel_language == 'Fortran':
-            solver = pyclaw.ClawSolver1D(riemann.vc_advection_1D)
+            solver = pyclaw.ClawSolver1D(riemann.advection_color_1D)
         elif kernel_language=='Python': 
             solver = pyclaw.ClawSolver1D(riemann.vc_advection_1D_py.vc_advection_1D)
     elif solver_type=='sharpclaw':
         if kernel_language == 'Fortran':
-            solver = pyclaw.SharpClawSolver1D(riemann.vc_advection_1D)
+            solver = pyclaw.SharpClawSolver1D(riemann.advection_color_1D)
         elif kernel_language=='Python': 
             solver = pyclaw.SharpClawSolver1D(riemann.vc_advection_1D_py.vc_advection_1D)
         solver.weno_order=weno_order

--- a/examples/advection_2d_annulus/advection_annulus.py
+++ b/examples/advection_2d_annulus/advection_annulus.py
@@ -4,17 +4,18 @@ r"""
 Advection in an annular domain
 ==============================
 
-Solve the linear advection equation:
+Solve the linear non-conservative advection equation:
 
 .. math::
-    q_t + (u(x,y) q)_x + (v(x,y) q)_y = 0
+    q_t + u(x,y) q_x + v(x,y) q_y = 0
 
 in an annular domain, using a mapped grid.
 
-Here q is the density of some conserved quantity and (u,v) is the velocity
+Here q is the density of some quantity and (u,v) is the velocity
 field.  We take a rotational velocity field: :math:`u = \cos(\theta), v = \sin(\theta)`.
 
 This is the simplest example that shows how to use a mapped grid in PyClaw.
+However, it doesn't use a mapped-grid Riemann solver.
 """
 from __future__ import absolute_import
 import numpy as np


### PR DESCRIPTION
Correctly state the equation to be solved.
Allow use of Fortran kernel.

Closes #654 .

Depends on https://github.com/clawpack/riemann/pull/162 (though tests will pass without that being merged, since we don't test this example).