### PR TITLE
Update reconstruct module initialization in Python

### DIFF
--- a/src/pyclaw/limiters/weno/reconstruct.c
+++ b/src/pyclaw/limiters/weno/reconstruct.c
@@ -5261,8 +5261,13 @@ static PyMethodDef reconstructmethods[] = {
 };
 
 PyMODINIT_FUNC
+#if PY_MAJOR_VERSION >= 3
+PyInit_reconstruct (void)
+#else
 initreconstruct (void)
+#endif
 {
+PyObject *module;  
 #if PY_MAJOR_VERSION >= 3
   static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
@@ -5275,9 +5280,13 @@ initreconstruct (void)
     NULL,                /* m_clear */
     NULL                 /* m_free */
   };
-  PyModule_Create(&moduledef);
+  module = PyModule_Create(&moduledef);
+  if (module == NULL)
+    return NULL;
+  return module;  
 #else
-  (void) Py_InitModule ("reconstruct", reconstructmethods);
+  module = Py_InitModule ("reconstruct", reconstructmethods);
+  if (module == NULL)
+    return NULL;
 #endif
-  import_array ();
 }

--- a/src/pyclaw/limiters/weno/reconstruct.c
+++ b/src/pyclaw/limiters/weno/reconstruct.c
@@ -5287,6 +5287,6 @@ PyObject *module;
 #else
   module = Py_InitModule ("reconstruct", reconstructmethods);
   if (module == NULL)
-    return NULL;
+    return;
 #endif
 }


### PR DESCRIPTION
Different APIs are used to initialize extension module in Python 2 and 3. This fixes reconstruct module initialization in Python 3.