### PR TITLE
Use integer division in WENO order.

### DIFF
--- a/src/pyclaw/limiters/reconstruct.py
+++ b/src/pyclaw/limiters/reconstruct.py
@@ -27,7 +27,7 @@ def weno(k, q):
     if (k % 2) == 0:
         raise ValueError('even order WENO reconstructions are not supported')
 
-    k = (k+1)/2
+    k = (k+1)//2
     sigma = np.zeros((q.shape[1], k))
     weights = np.zeros((q.shape[1], k))
 


### PR DESCRIPTION
Uses Python 3 integer division.  This fixes the error seen in https://github.com/clawpack/clawpack/pull/206, which presumably was caused by a breaking change to numpy.