### PR TITLE
Support reading output files in format binary32

### DIFF
--- a/src/pyclaw/controller.py
+++ b/src/pyclaw/controller.py
@@ -458,6 +458,11 @@ class OutputController(object):
             self._io_module = __import__("clawpack.petclaw.fileio.petsc",
                                          fromlist=["clawpack.petclaw.fileio"])
             self._file_format = value
+        elif value.lower()[:6] == 'binary':
+            # could be 'binary64' or 'binary32'
+            self._io_module = __import__("clawpack.pyclaw.fileio.binary",
+                                         fromlist=['clawpack.pyclaw.fileio'])
+            self._file_format = value
         else:
             self._io_module = __import__("clawpack.pyclaw.fileio.%s" % value,
                                          fromlist=['clawpack.pyclaw.fileio'])

--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -289,10 +289,6 @@ def read_t(frame,path='./',file_prefix='fort'):
             file_format = read_data_line(f, data_type=str)
         except:
             file_format = None
-        print('+++ file_format in read_t: ',file_format)
-
-    #file_format_map = {1:'ascii', 2:'binary32', 3:'binary64'}
-    #file_format = file_format_map[file_format_int]
         
     return t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format
 

--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -167,7 +167,8 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
     q_fname = os.path.join(base_path, '%s.q' % file_prefix) + str(frame).zfill(4)
 
     # Read in values from fort.t file:
-    [t,num_eqn,nstates,num_aux,num_dim] = read_t(frame,path,file_prefix)
+    [t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format] = \
+         read_t(frame,path,file_prefix)
 
     patches = []
 
@@ -237,9 +238,20 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
 
                 state.aux = read_array(f, state, num_aux)
 
-            
+        
 def read_t(frame,path='./',file_prefix='fort'):
-    r"""Read only the fort.t file and return the data
+    r"""Read only the fort.t file and return the data.
+
+    Note this file is always ascii and now contains a line that tells
+    the file_format, so we can read this file before importing the 
+    appropriate read function for the solution data.
+
+    For backward compatibility, if file_format line is missing then
+    return None and handle this where it is called.
+
+    This version also reads in num_ghost so that if the data is binary,
+    we can extract only the data that's relevant (since ghost cells are
+    included).
     
     :Input:
      - *frame* - (int) Frame number to be read in
@@ -252,22 +264,38 @@ def read_t(frame,path='./',file_prefix='fort'):
      - *t* - (int) Time of frame
      - *num_eqn* - (int) Number of equations in the frame
      - *nstates* - (int) Number of states
-     - *num_aux* - (int) Auxillary value in the frame
+     - *num_aux* - (int) Auxiliary value in the frame
      - *num_dim* - (int) Number of dimensions in q and aux
+     - *num_ghost* - (int) Number of ghost cells on each side
+     - *file_format* - (str) 'ascii', 'binary32', 'binary64'
     
     """
+
+    from clawpack.pyclaw.util import read_data_line
+    import logging
+    logger = logging.getLogger('pyclaw.fileio')
 
     base_path = os.path.join(path,)
     path = os.path.join(base_path, '%s.t' % file_prefix) + str(frame).zfill(4)
     logger.debug("Opening %s file." % path)
     with open(path,'r') as f:
         t = read_data_line(f)
-        num_eqn = read_data_line(f,data_type=int)
-        nstates = read_data_line(f,data_type=int)
-        num_aux = read_data_line(f,data_type=int)
-        num_dim = read_data_line(f,data_type=int)
-    
-    return t, num_eqn, nstates, num_aux, num_dim
+        num_eqn = read_data_line(f, data_type=int)
+        nstates = read_data_line(f, data_type=int)
+        num_aux = read_data_line(f, data_type=int)
+        num_dim = read_data_line(f, data_type=int)
+        num_ghost = read_data_line(f, data_type=int)
+        try:
+            file_format = read_data_line(f, data_type=str)
+        except:
+            file_format = None
+        print('+++ file_format in read_t: ',file_format)
+
+    #file_format_map = {1:'ascii', 2:'binary32', 3:'binary64'}
+    #file_format = file_format_map[file_format_int]
+        
+    return t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format
+
 
 
 def read_patch_header(f, num_dim):

--- a/src/pyclaw/fileio/binary.py
+++ b/src/pyclaw/fileio/binary.py
@@ -53,7 +53,6 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
     # Read in values from fort.t file:
     [t,num_eqn,nstates,num_aux,num_dim,num_ghost] = read_t(frame,path,file_prefix)
 
-    print('+++ in binary read, options = ',options)
     patches = []
     
     # Read in values from fort.b file:

--- a/src/pyclaw/fileio/binary.py
+++ b/src/pyclaw/fileio/binary.py
@@ -44,6 +44,7 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
      - *options* - (dict) Dictionary of optional arguments dependent on 
        the format being read in.  ``default = {}``
     """
+    from clawpack.pyclaw.fileio.ascii import read_t
     
     # Construct path names
     base_path = os.path.join(path,)
@@ -51,7 +52,8 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
     b_fname = os.path.join(base_path, '%s.b' % file_prefix) + str(frame).zfill(4)
 
     # Read in values from fort.t file:
-    [t,num_eqn,nstates,num_aux,num_dim,num_ghost] = read_t(frame,path,file_prefix)
+    [t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format] = \
+        read_t(frame,path,file_prefix)
 
     patches = []
     
@@ -204,41 +206,4 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
                 raise Exception(msg)
 
             i_start_patch = i_end_patch  # prepare for next patch
-
-            
-def read_t(frame,path='./',file_prefix='fort'):
-    r"""Read only the fort.t file and return the data.
-
-    Note that this version reads in the extra value for num_ghost so that we
-    can extract only the data that's relevant.
-    
-    :Input:
-     - *frame* - (int) Frame number to be read in
-     - *path* - (string) Path to the current directory of the file
-     - *file_prefix* - (string) Prefix of the files to be read in.  
-       ``default = 'fort'``
-     
-    :Output:
-     - (list) List of output variables
-     - *t* - (int) Time of frame
-     - *num_eqn* - (int) Number of equations in the frame
-     - *nstates* - (int) Number of states
-     - *num_aux* - (int) Auxiliary value in the frame
-     - *num_dim* - (int) Number of dimensions in q and aux
-     - *num_ghost* - (int) Number of ghost cells on each side
-    
-    """
-
-    base_path = os.path.join(path,)
-    path = os.path.join(base_path, '%s.t' % file_prefix) + str(frame).zfill(4)
-    logger.debug("Opening %s file." % path)
-    with open(path,'r') as f:
-        t = read_data_line(f)
-        num_eqn = read_data_line(f, data_type=int)
-        nstates = read_data_line(f, data_type=int)
-        num_aux = read_data_line(f, data_type=int)
-        num_dim = read_data_line(f, data_type=int)
-        num_ghost = read_data_line(f, data_type=int)
-        
-    return t,num_eqn,nstates,num_aux,num_dim,num_ghost
 

--- a/src/pyclaw/fileio/binary.py
+++ b/src/pyclaw/fileio/binary.py
@@ -166,7 +166,14 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
             
         # Found a valid path, try to open and read it
         with open(fname,'rb') as b_file:
-            auxdata = np.fromfile(file=b_file, dtype=np.float64)
+            if file_format in ['binary', 'binary64']:
+                auxdata = np.fromfile(file=b_file, dtype=np.float64)
+            elif file_format == 'binary32':
+                auxdata = np.fromfile(file=b_file, dtype=np.float32)
+            else:
+                msg = "Unrecognized file_format: %s" % file_format
+                logger.critical(msg)
+                raise Exception(msg)
 
         i_start_patch = 0  # index into auxdata for start of next patch
         for state in solution.states:

--- a/src/pyclaw/fileio/binary.py
+++ b/src/pyclaw/fileio/binary.py
@@ -55,9 +55,18 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
 
     patches = []
     
-    # Read in values from fort.q file:
+    # Read in values from fort.b file:
+    file_format = options.get('format','binary64')
+    
     with open(b_fname,'rb') as b_file:
-        qdata = np.fromfile(file=b_file, dtype=np.float64)
+        if file_format in ['binary', 'binary64']:
+            qdata = np.fromfile(file=b_file, dtype=np.float64)
+        elif file_format == 'binary32':
+            qdata = np.fromfile(file=b_file, dtype=np.float32)
+        else:
+            msg = "Unrecognized format: %s" % file_format
+            logger.critical(msg)
+            raise Exception(msg)
 
     i_start_patch = 0  # index into qdata for start of next patch
     n     = np.zeros((num_dim),dtype=int)

--- a/src/pyclaw/fileio/binary.py
+++ b/src/pyclaw/fileio/binary.py
@@ -53,6 +53,7 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
     # Read in values from fort.t file:
     [t,num_eqn,nstates,num_aux,num_dim,num_ghost] = read_t(frame,path,file_prefix)
 
+    print('+++ in binary read, options = ',options)
     patches = []
     
     # Read in values from fort.b file:
@@ -64,7 +65,7 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
         elif file_format == 'binary32':
             qdata = np.fromfile(file=b_file, dtype=np.float32)
         else:
-            msg = "Unrecognized format: %s" % file_format
+            msg = "Unrecognized file_format: %s" % file_format
             logger.critical(msg)
             raise Exception(msg)
 

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -340,9 +340,11 @@ class Solution(object):
         :Output:
          - (bool) - True if read was successful, False otherwise
         """
+
+        from clawpack.pyclaw.fileio.ascii import read_t
         
         [t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format2] = \
-             self.read_t(frame,path,file_prefix=file_prefix)
+             read_t(frame,path,file_prefix=file_prefix)
 
         if file_format2 is not None:
             # value was read in from file, use it:
@@ -359,62 +361,6 @@ class Solution(object):
             read_func(self,frame,path,file_prefix=file_prefix,
                                     read_aux=read_aux,options=options)
         logging.getLogger('pyclaw.fileio').info("Read in solution for time t=%s" % self.t)
-
-            
-    def read_t(self,frame,path='./',file_prefix='fort'):
-        r"""Read only the fort.t file and return the data.
-
-        Note this file is always ascii and now contains a line that tells
-        the file_format.  Adapted from fileio.binary.read_t so that we can
-        read the file_format before importing the appropriate read function.
-
-        For backward compatibility, if file_format line is missing then
-        return None and handle this elsewhere.
-
-        This version also reads in num_ghost so that we
-        can extract only the data that's relevant.
-        
-        :Input:
-         - *frame* - (int) Frame number to be read in
-         - *path* - (string) Path to the current directory of the file
-         - *file_prefix* - (string) Prefix of the files to be read in.  
-           ``default = 'fort'``
-         
-        :Output:
-         - (list) List of output variables
-         - *t* - (int) Time of frame
-         - *num_eqn* - (int) Number of equations in the frame
-         - *nstates* - (int) Number of states
-         - *num_aux* - (int) Auxiliary value in the frame
-         - *num_dim* - (int) Number of dimensions in q and aux
-         - *num_ghost* - (int) Number of ghost cells on each side
-         - *file_format* - (str) 'ascii', 'binary32', 'binary64'
-        
-        """
-
-        from .util import read_data_line
-        import logging
-        logger = logging.getLogger('pyclaw.fileio')
-
-        base_path = os.path.join(path,)
-        path = os.path.join(base_path, '%s.t' % file_prefix) + str(frame).zfill(4)
-        logger.debug("Opening %s file." % path)
-        with open(path,'r') as f:
-            t = read_data_line(f)
-            num_eqn = read_data_line(f, data_type=int)
-            nstates = read_data_line(f, data_type=int)
-            num_aux = read_data_line(f, data_type=int)
-            num_dim = read_data_line(f, data_type=int)
-            num_ghost = read_data_line(f, data_type=int)
-            try:
-                file_format = read_data_line(f, data_type=str)
-            except:
-                file_format = None
-
-        #file_format_map = {1:'ascii', 2:'binary32', 3:'binary64'}
-        #file_format = file_format_map[file_format_int]
-            
-        return t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format
 
 
     def get_read_func(self, file_format):

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -357,7 +357,7 @@ class Solution(object):
             import clawpack.pyclaw.fileio.binary
             return clawpack.pyclaw.fileio.binary.read
         elif file_format == 'ascii':
-            import clawpack.pyclaw.fileio.binary
+            import clawpack.pyclaw.fileio.ascii
             return clawpack.pyclaw.fileio.ascii.read
         elif file_format in ('hdf','hdf5'):
             import clawpack.pyclaw.fileio.hdf5

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -352,7 +352,8 @@ class Solution(object):
 
 
     def get_read_func(self, file_format):
-        if file_format == 'binary':
+        if file_format[:6] == 'binary':
+            # could be 'binary64' or 'binary32'
             import clawpack.pyclaw.fileio.binary
             return clawpack.pyclaw.fileio.binary.read
         elif file_format == 'ascii':

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -340,15 +340,9 @@ class Solution(object):
          - (bool) - True if read was successful, False otherwise
         """
         
-        if file_format is not None:
-            print('+++ solution.read called with file_format = ',file_format)
-        print('+++ solution.read called with file_prefix = ',file_prefix)
-
-        print('+++ calling read_t with arguments: ',frame,path,file_prefix)
         [t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format] = \
              self.read_t(frame,path,file_prefix=file_prefix)
 
-        print('+++ read_t returned file_format = ',file_format)
 
         read_func = self.get_read_func(file_format)
 
@@ -415,7 +409,6 @@ class Solution(object):
 
 
     def get_read_func(self, file_format):
-        print('+++ importing read for file_format = ',file_format)
         if file_format[:6] == 'binary':
             # could be 'binary64' or 'binary32'
             import clawpack.pyclaw.fileio.binary

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -330,7 +330,8 @@ class Solution(object):
          - *path* - (string) Base path to the files to be read. 
            ``default = './_output'``
          - *file_format* - (string) Format of the file, should match on of the 
-           modules inside of the io package.  ``default = 'ascii'``
+           modules inside of the io package.  ``default = None``
+           but now attempts to read from header file (as of v5.9.0).
          - *file_prefix* - (string) Name prefix in front of all the files, 
            defaults to whatever the format defaults to, e.g. fort for ascii
          - *options* - (dict) Dictionary of optional arguments dependent on 
@@ -340,9 +341,12 @@ class Solution(object):
          - (bool) - True if read was successful, False otherwise
         """
         
-        [t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format] = \
+        [t,num_eqn,nstates,num_aux,num_dim,num_ghost,file_format2] = \
              self.read_t(frame,path,file_prefix=file_prefix)
 
+        if file_format2 is not None:
+            # value was read in from file, use it:
+            file_format = file_format2
 
         read_func = self.get_read_func(file_format)
 
@@ -363,6 +367,9 @@ class Solution(object):
         Note this file is always ascii and now contains a line that tells
         the file_format.  Adapted from fileio.binary.read_t so that we can
         read the file_format before importing the appropriate read function.
+
+        For backward compatibility, if file_format line is missing then
+        return None and handle this elsewhere.
 
         This version also reads in num_ghost so that we
         can extract only the data that's relevant.
@@ -399,8 +406,10 @@ class Solution(object):
             num_aux = read_data_line(f, data_type=int)
             num_dim = read_data_line(f, data_type=int)
             num_ghost = read_data_line(f, data_type=int)
-            file_format = read_data_line(f, data_type=str)
-            #file_format_int = read_data_line(f, data_type=int)
+            try:
+                file_format = read_data_line(f, data_type=str)
+            except:
+                file_format = None
 
         #file_format_map = {1:'ascii', 2:'binary32', 3:'binary64'}
         #file_format = file_format_map[file_format_int]


### PR DESCRIPTION
Support reading `fort.bxxxx` files that are either `binary64` == `binary` or `binary32` format. 