### PR TITLE
Fix various typos

### DIFF
--- a/development/DMPFOR/dmpfor_test.py
+++ b/development/DMPFOR/dmpfor_test.py
@@ -56,22 +56,22 @@ print("da array from fortran")
 DMPFOR.dmpfor(q,dof,nx,ny)
 
 
-print("da array from python after rolling axises using rollaxis")
+print("da array from python after rolling axes using rollaxis")
 rolled_q_1 = np.rollaxis(q,0,3)
 rolled_q_1 = np.reshape(rolled_q_1,(nx,ny,dof),order='F')
 print(rolled_q_1)
-print("da array from fortran after rolling axises using rollaxis")
+print("da array from fortran after rolling axes using rollaxis")
 DMPFOR.dmpfor(rolled_q_1,nx,ny,dof)
 
 
-print("da array from python after rolling axises using element by element copy")
+print("da array from python after rolling axes using element by element copy")
 rolled_q_2 = np.empty((nx,ny,dof),order='F')
 for i in range(0,nx):
     for j in range(0,ny):
         for k in range(0,dof):
             rolled_q_2[i,j,k] = q[k,i,j]
 print(rolled_q_2)
-print("da array from fortran after rolling axises using element by element copy")
+print("da array from fortran after rolling axes using element by element copy")
 DMPFOR.dmpfor(rolled_q_2,nx,ny,dof)
 
 

--- a/development/clawdata2pyclaw.py
+++ b/development/clawdata2pyclaw.py
@@ -3,7 +3,7 @@ Script to convert Clawpack 4.6.x problem setup to PyClaw setup.
 Automatically writes a basic PyClaw script with all the options
 from the setrun.py in the current directory.  Also generates a 
 Makefile and a wrapper for qinit.f.  Additional wrappers will be
-needed for any other custom Fortan code, such as setaux, b4step, etc.
+needed for any other custom Fortran code, such as setaux, b4step, etc.
 
 If you try this out, please raise issues in the PyClaw tracker for 
 anything that doesn't work.

--- a/development/point_wise_rs/pyWrapperForRiemannSolver/riemannSolverSerialTimer.py
+++ b/development/point_wise_rs/pyWrapperForRiemannSolver/riemannSolverSerialTimer.py
@@ -16,7 +16,7 @@ max_timeSteps = 101
 timesStepsValues = empty((noOfTestSamples ))
 timeResultsVectorized =empty((noOfTestSamples ))
 timeResultsPointwise =empty((noOfTestSamples ))
-# error when max_mx is devisible by noOfTestSamples. size of arrays should be noOfTestSamples-1, use j to decide what to plot
+# error when max_mx is divisible by noOfTestSamples. size of arrays should be noOfTestSamples-1, use j to decide what to plot
 
 
 
@@ -71,7 +71,7 @@ max_timeSteps = 101
 mxValues = empty((noOfTestSamples ))
 timeResultsVectorized =empty((noOfTestSamples ))
 timeResultsPointwise =empty((noOfTestSamples ))
-# error when max_mx is devisible by noOfTestSamples. size of arrays should be noOfTestSamples-1, use j to decide what to plot
+# error when max_mx is divisible by noOfTestSamples. size of arrays should be noOfTestSamples-1, use j to decide what to plot
 
 
 

--- a/development/rp_approaches/rp2_euler_5wave_module.f90
+++ b/development/rp_approaches/rp2_euler_5wave_module.f90
@@ -80,7 +80,7 @@ contains
 !
 !     # note that notation for u and v reflects assumption that the 
 !     # Riemann problems are in the x-direction with u in the normal
-!     # direciton and v in the orthogonal direcion, but with the above
+!     # direction and v in the orthogonal direction, but with the above
 !     # definitions of mu and mv the routine also works with ixy=2
 !     # and returns, for example, f0 as the Godunov flux g0 for the
 !     # Riemann problems u_t + g(u)_y = 0 in the y-direction.

--- a/development/rp_approaches/rpn2_euler_5wave.f
+++ b/development/rp_approaches/rpn2_euler_5wave.f
@@ -74,7 +74,7 @@ c
 c
 c     # note that notation for u and v reflects assumption that the 
 c     # Riemann problems are in the x-direction with u in the normal
-c     # direciton and v in the orthogonal direcion, but with the above
+c     # direction and v in the orthogonal direction, but with the above
 c     # definitions of mu and mv the routine also works with ixy=2
 c     # and returns, for example, f0 as the Godunov flux g0 for the
 c     # Riemann problems u_t + g(u)_y = 0 in the y-direction.

--- a/development/rp_approaches/rpn2_euler_5wave_aux.f
+++ b/development/rp_approaches/rpn2_euler_5wave_aux.f
@@ -71,7 +71,7 @@ c
 c
 c     # note that notation for u and v reflects assumption that the 
 c     # Riemann problems are in the x-direction with u in the normal
-c     # direciton and v in the orthogonal direcion, but with the above
+c     # direction and v in the orthogonal direction, but with the above
 c     # definitions of mu and mv the routine also works with ixy=2
 c     # and returns, for example, f0 as the Godunov flux g0 for the
 c     # Riemann problems u_t + g(u)_y = 0 in the y-direction.

--- a/development/rp_approaches/rpn2_euler_5wave_rec_loc.f
+++ b/development/rp_approaches/rpn2_euler_5wave_rec_loc.f
@@ -64,7 +64,7 @@ c
 c
 c     # note that notation for u and v reflects assumption that the 
 c     # Riemann problems are in the x-direction with u in the normal
-c     # direciton and v in the orthogonal direcion, but with the above
+c     # direction and v in the orthogonal direction, but with the above
 c     # definitions of mu and mv the routine also works with ixy=2
 c     # and returns, for example, f0 as the Godunov flux g0 for the
 c     # Riemann problems u_t + g(u)_y = 0 in the y-direction.

--- a/development/rp_approaches/rpn2_euler_5wave_recompute.f
+++ b/development/rp_approaches/rpn2_euler_5wave_recompute.f
@@ -74,7 +74,7 @@ c
 c
 c     # note that notation for u and v reflects assumption that the 
 c     # Riemann problems are in the x-direction with u in the normal
-c     # direciton and v in the orthogonal direcion, but with the above
+c     # direction and v in the orthogonal direction, but with the above
 c     # definitions of mu and mv the routine also works with ixy=2
 c     # and returns, for example, f0 as the Godunov flux g0 for the
 c     # Riemann problems u_t + g(u)_y = 0 in the y-direction.

--- a/examples/acoustics_2d_mapped/acoustics_2d_inclusions.py
+++ b/examples/acoustics_2d_mapped/acoustics_2d_inclusions.py
@@ -60,7 +60,7 @@ def inclusion_mapping(xc, yc):
         R = r1*np.ones(d1.shape)
         R = r1**2 / (r2*d)
 
-        # Modify d1 and R ouside circle to morph back to square:
+        # Modify d1 and R outside circle to morph back to square:
         ij = np.where(d>(r1/r2))
         d1[ij] = r1/np.sqrt(2) + (d[ij]-r1/r2)*(r2-r1/np.sqrt(2))/(1.-r1/r2)
         R[ij] = r1 * ((1.-r1/r2) / (1.-d[ij]))**(r2/r1 + 0.5)

--- a/examples/advection_1d/advection_1d_nonunif.py
+++ b/examples/advection_1d/advection_1d_nonunif.py
@@ -45,7 +45,7 @@ def setup(nx=100, kernel_language='Fortran', use_petsc=False, solver_type='class
     elif kernel_language == 'Python':
         riemann_solver = riemann.advection_1D_py.advection_1D
 
-    # sharpclaw does not accomodate nonuniform grids
+    # sharpclaw does not accommodate nonuniform grids
     if solver_type=='classic':
         solver = pyclaw.ClawSolver1D(riemann_solver)
     else: raise Exception('Unrecognized value of solver_type.')

--- a/examples/advection_1d_variable/variable_coefficient_advection.py
+++ b/examples/advection_1d_variable/variable_coefficient_advection.py
@@ -46,7 +46,7 @@ def qinit(state):
 
 
 def auxinit(state):
-    # Initilize petsc Structures for aux
+    # Initialize petsc Structures for aux
     xc=state.grid.x.centers
     state.aux[0,:] = np.sin(2.*np.pi*xc)+2
     

--- a/examples/compare_solvers.py
+++ b/examples/compare_solvers.py
@@ -10,7 +10,7 @@ import six
 
 def debug_loggers():
     """
-    Turn on maximimum debugging from all loggers.
+    Turn on maximum debugging from all loggers.
     """
 
     root_logger = logging.getLogger()

--- a/examples/shallow_sphere/Rossby_wave.py
+++ b/examples/shallow_sphere/Rossby_wave.py
@@ -276,10 +276,10 @@ def qinit(state,mx,my):
 
             # Radial velocity component
             Uin[2] = 0.0 # The fluid does not enter in the sphere
-            
 
-            # Calculate velocity vetor in cartesian coordinates
-            # =================================================
+
+            # Calculate velocity vector in cartesian coordinates
+            # ==================================================
             Uout = np.zeros(3)
 
             Uout[0] = (-np.sin(xp)*Uin[0]-np.sin(yp)*np.cos(xp)*Uin[1])
@@ -420,7 +420,7 @@ def setup(use_petsc=False,solver_type='classic',outdir='./_output', disable_outp
 
     # Check whether or not the even number of cells are used in in both 
     # directions. If odd numbers are used a message is print at screen and the 
-    # simulation is interrputed.
+    # simulation is interrupted.
     if(mx % 2 != 0 or my % 2 != 0):
         message = 'Please, use even numbers of cells in both direction. ' \
                   'Only even numbers allow to impose correctly the boundary ' \

--- a/examples/shallow_sphere/qinit.f90
+++ b/examples/shallow_sphere/qinit.f90
@@ -89,7 +89,7 @@ subroutine qinit(maxmx,maxmy,num_eqn,num_ghost,mx,my,xlower,ylower, &
             Uin(3) = 0.d0
         
 
-            ! calculate velocity vetor in cartesian coordinates
+            ! calculate velocity vector in cartesian coordinates
             Uout(1) = (-dsin(xp)*Uin(1)-dsin(yp)*dcos(xp)*Uin(2))
             Uout(2) = (dcos(xp)*Uin(1)-dsin(yp)*dsin(xp)*Uin(2))
             Uout(3) = dcos(yp)*Uin(2)

--- a/src/petclaw/fileio/petsc.py
+++ b/src/petclaw/fileio/petsc.py
@@ -211,7 +211,7 @@ def read_t(frame,path='./',file_prefix='claw'):
       - *t* - (int) Time of frame
       - *num_eqn* - (int) Number of equations in the frame
       - *npatches* - (int) Number of patches
-      - *num_aux* - (int) Auxillary value in the frame
+      - *num_aux* - (int) Auxiliary value in the frame
       - *num_dim* - (int) Number of dimensions in q and aux
     
     """

--- a/src/pyclaw/controller.py
+++ b/src/pyclaw/controller.py
@@ -287,7 +287,7 @@ class Controller(object):
         :Input:
             None
 
-        :Ouput:
+        :Output:
             (dict) - Return a dictionary of the status of the solver.
         """
         import numpy as np

--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -25,9 +25,9 @@ def write(solution, frame, path, file_prefix='fort', write_aux=False,
     including writing out fort.t, fort.q, and fort.aux if necessary.  Note
     that there are some parameters that assumed to be the same for every patch
     in this format which is not necessarily true for the actual data objects.
-    Make sure that if you use this output format that all of you patchs share
-    the appropriate values of num_dim, num_eqn, num_aux, and t.  Only supports up to
-    3 dimensions.
+    Make sure that if you use this output format that all of your patches share
+    the appropriate values of num_dim, num_eqn, num_aux, and t.  Only supports
+    up to 3 dimensions.
     
     :Input:
      - *solution* - (:class:`~pyclaw.solution.Solution`) Pyclaw object to be 
@@ -143,7 +143,7 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
      - *path* - (string) Path to the current directory of the file
      - *file_prefix* - (string) Prefix of the files to be read in.  
        ``default = 'fort'``
-     - *read_aux* (bool) Whether or not an auxillary file will try to be read 
+     - *read_aux* (bool) Whether or not an auxiliary file will try to be read 
        in.  ``default = False``
      - *options* - (dict) Dictionary of optional arguments dependent on 
        the format being read in.  ``default = {}``
@@ -200,7 +200,7 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
 
     solution.domain = pyclaw.geometry.Domain(patches)
 
-    # Read auxillary file if available and requested
+    # Read auxiliary file if available and requested
     # Matching dimension parameter tolerances
     ABS_TOL = 1e-8
     REL_TOL = 1e-15
@@ -216,7 +216,7 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
             fname = fname2
             # Note that this is generally not true when AMR is used.
         else:
-            logger.debug("Unable to open auxillary file %s or %s" % (fname1,fname2))
+            logger.debug("Unable to open auxiliary file %s or %s" % (fname1,fname2))
             return
             
         # Read in fort.auxxxxx file

--- a/src/pyclaw/fileio/claw_vtk.py
+++ b/src/pyclaw/fileio/claw_vtk.py
@@ -101,7 +101,7 @@ def write(
 
     Notes on what is not yet implemented
         - Add options for writing aux files.
-        - Consider making an equilvalent vtk.read function.
+        - Consider making an equivalent vtk.read function.
     """
     # get options from the options dictionary.
     binary = options.get("binary", False)
@@ -239,7 +239,7 @@ def _set_overlapped_status(sol):
     whose entries denote overlapped status for each patch.
 
     @type sol:  pyclaw.Solution
-    @param sol: Solution obejct of pyclaw that contains all information
+    @param sol: Solution object of pyclaw that contains all information
                 of this time step.
     @rtype:     list
     @return:    add a component to the solution q,

--- a/src/pyclaw/gauges.py
+++ b/src/pyclaw/gauges.py
@@ -427,7 +427,7 @@ def compare_old_gauges(old_path, new_path, gauge_id, plot=False, abs_tol=1e-14,
 
     # Turn these into assertions or logicals
     if verbose:
-        print("Comparison of guage %s:" % gauge_id)
+        print("Comparison of gauge %s:" % gauge_id)
         print(r"           ||\Delta q||_2 = ",
                               numpy.linalg.norm(q - gauge.q.transpose(), ord=2))
         print(r"  arg(||\Delta q||_\infty = ",
@@ -449,7 +449,7 @@ def compare_old_gauges(old_path, new_path, gauge_id, plot=False, abs_tol=1e-14,
 def check_old_gauge_data(path, gauge_id, new_gauge_path="./regression_data"):
     """Compare old gauge data to new gauge format
 
-    Function is meant to check discrepencies between versions of the gauge
+    Function is meant to check discrepancies between versions of the gauge
     files.  Note that this function also directly prints out some info.
 
     :Input:
@@ -495,7 +495,7 @@ if __name__ == "__main__":
 
 Plots a comparison between the gauges at path1 and path2 with gauge_id and the 
 fields specified.  Only one gauge_id can be specified at a time but a number of 
-fields can be specfied including 'all'.
+fields can be specified including 'all'.
 """
 
     fields = 'all'

--- a/src/pyclaw/limiters/tvd.py
+++ b/src/pyclaw/limiters/tvd.py
@@ -64,7 +64,7 @@ in review.
 """
 # ============================================================================
 #      Copyright (C) 2008 Kyle T. Mandli <mandli@amath.washington.edu>
-#      Copyrigth (C) 2009 Randall J. LeVeque <rjl@amath.washington.edu>
+#      Copyright (C) 2009 Randall J. LeVeque <rjl@amath.washington.edu>
 #
 #  Distributed under the terms of the Berkeley Software Distribution (BSD) 
 #  license

--- a/src/pyclaw/sharpclaw/solver.py
+++ b/src/pyclaw/sharpclaw/solver.py
@@ -664,7 +664,7 @@ class SharpClawSolver(Solver):
                     rho = 0.6 if len(self._registers)== 4 else 0.57
                     self.dt = rho * self.dt
             else:
-                # Step size selection guarantees CFL condition is satified.
+                # Step size selection guarantees CFL condition is satisfied.
                 # Only need to check 3rd-order LMM's condition
                 if self.accept_step:
                     s = len(self._registers)

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -273,7 +273,7 @@ class Solution(object):
            containing the desired output formats. ``default = 'ascii'``
          - *file_prefix* - (string) Prefix for the file name.  Defaults to
            the particular io modules default.
-         - *write_aux* - (book) Write the auxillary array out as well if 
+         - *write_aux* - (book) Write the auxiliary array out as well if 
            present. ``default = False``
          - *options* - (dict) Dictionary of optional arguments dependent on 
            which format is being used. ``default = {}``

--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -95,7 +95,7 @@ class Solver(object):
 
     .. attribute:: max_steps
 
-        The maximum number of time steps allowd to reach the end time
+        The maximum number of time steps allowed to reach the end time
         requested, ``default = 10000``.  If exceeded, an exception is
         raised.
 
@@ -448,7 +448,7 @@ class Solver(object):
         :Input:
          - *patch* - (:class:`Patch`) Patch that the dimension belongs to.
 
-        :Input/Ouput:
+        :Input/Output:
          - *array* - (ndarray(...,num_eqn)) Array with added ghost cells which
            will be set in this routines.
         """
@@ -489,7 +489,7 @@ class Solver(object):
         :Input:
          - *patch* - (:class:`Patch`) Patch that the dimension belongs to
 
-        :Input/Ouput:
+        :Input/Output:
          - *array* - (ndarray(...,num_eqn)) Array with added ghost cells which will
            be set in this routines
         """

--- a/src/pyclaw/state.py
+++ b/src/pyclaw/state.py
@@ -10,7 +10,7 @@ import six
 class State(object):
     r"""
     A PyClaw State object contains the current state on a particular patch,
-    including the unkowns q, the time t, and the auxiliary coefficients aux.
+    including the unknowns q, the time t, and the auxiliary coefficients aux.
 
     The variables num_eqn and num_aux determine the length of the first
     dimension of the q and aux arrays.

--- a/src/pyclaw/util.py
+++ b/src/pyclaw/util.py
@@ -714,7 +714,7 @@ class FrameCounter:
     Simple frame counter
 
     Simple frame counter to keep track of current frame number.  This can
-    also be used to keep multiple runs frames seperated by having multiple
+    also be used to keep multiple runs frames separated by having multiple
     counters at once.
 
     Initializes to 0


### PR DESCRIPTION
Found via `codespell -q 3 -L ans,inout,nd,parm`