### PR TITLE
Write num_ghost = 0 in PyClaw ASCII output.

### DIFF
--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -49,6 +49,7 @@ def write(solution, frame, path, file_prefix='fort', write_aux=False,
         f.write("%5i                  num_aux\n" % solution.num_aux)
         f.write("%5i                  num_dim\n" % solution.domain.num_dim)
         f.write("%5i                  num_ghost\n" % 0)
+        f.write("%s                  file_format\n" % "ascii")
 
     # Write fort.qxxxx file
     file_name = 'fort.q%s' % str(frame).zfill(4)

--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -48,6 +48,7 @@ def write(solution, frame, path, file_prefix='fort', write_aux=False,
         f.write("%5i                  nstates\n" % len(solution.states))
         f.write("%5i                  num_aux\n" % solution.num_aux)
         f.write("%5i                  num_dim\n" % solution.domain.num_dim)
+        f.write("%5i                  num_ghost\n" % 0)
 
     # Write fort.qxxxx file
     file_name = 'fort.q%s' % str(frame).zfill(4)
@@ -284,7 +285,10 @@ def read_t(frame,path='./',file_prefix='fort'):
         nstates = read_data_line(f, data_type=int)
         num_aux = read_data_line(f, data_type=int)
         num_dim = read_data_line(f, data_type=int)
-        num_ghost = read_data_line(f, data_type=int)
+        try:
+            num_ghost = read_data_line(f, data_type=int)
+        except:
+            num_ghost = 0
         try:
             file_format = read_data_line(f, data_type=str)
         except:


### PR DESCRIPTION
Resolves #691.

I also added a try/except block in the read function, so that if one uses the new read function with old output files it should work.  There is a chance of something funky happening there since there was already a try/except block for the file format, but I think the probability of this being an issue is small enough to be worth the convenience of the backward compatibility.