### PR TITLE
change getargspec to getfullargspec to support python 3.11

### DIFF
--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -326,7 +326,7 @@ class Solver(object):
         import inspect
         for fun in (self.user_bc_lower,self.user_bc_upper,self.user_aux_bc_lower,self.user_aux_bc_upper):
             if fun is not None:
-                args = inspect.getargspec(fun)[0]
+                args = inspect.getfullargspec(fun)[0]
                 if len(args) == 5:
                     self.logger.warn("""The custom boundary condition
                                         function signature has been changed.


### PR DESCRIPTION
I found this little change to be necessary for the tests to pass in conda-forge. More info here: https://docs.python.org/3/library/inspect.html#inspect.getfullargspec

xref: https://github.com/conda-forge/clawpack-feedstock/pull/15