### PR TITLE
Use fortran ordering for q array when reading ascii files.

### DIFF
--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -355,7 +355,7 @@ def read_array(f, state, num_var):
     """
     patch = state.patch
     q_shape = [num_var] + patch.num_cells_global
-    q = np.zeros(q_shape)
+    q = np.zeros(q_shape, order='F')
 
 
     try:


### PR DESCRIPTION
This fixes an error reported here: https://groups.google.com/g/claw-users/c/lcDROYpRMxY/m/sDW_gINPCAAJ?utm_medium=email&utm_source=footer

The issue is that when reading ASCII files, the solution.state.q array is created with C ordering instead of Fortran ordering.