### PR TITLE
Fix bug before step function not being called

### DIFF
--- a/src/pyclaw/sharpclaw/solver.py
+++ b/src/pyclaw/sharpclaw/solver.py
@@ -337,9 +337,11 @@ class SharpClawSolver(Solver):
             num_stages = len(self.b)
             for i in range(1,num_stages):
                 self._registers[i].q[:] = state.q
+                self._registers[i].t = state.t + self.dt*self.c[i]
+                if self.call_before_step_each_stage:
+                    self.before_step(self,self._registers[i])
                 for j in range(i):
                     self._registers[i].q += self.a[i,j]*self._registers[j].q
-                self._registers[i].t = state.t + self.dt*self.c[i]
 
                 # self._registers[i].q eventually stores dt*f(y_i) after stage solution y_i is computed
                 self._registers[i].q = self.dq(self._registers[i])


### PR DESCRIPTION
The function solver.before_step was not being called before each RK stage when solver.time_integrator='RK' and
solver.call_before_step_each_stage=True. The bug is fixed in this commit.
solver._registers[i].t is now updated earlier in case the before_step function depends on t.