### PR TITLE
fixed read issues in test_sedov_and_hdf.

### DIFF
--- a/examples/euler_3d/test_sedov_and_hdf.py
+++ b/examples/euler_3d/test_sedov_and_hdf.py
@@ -18,11 +18,11 @@ def test_sedov_and_hdf():
         from clawpack.pyclaw import Solution
         
         thisdir = os.path.dirname(__file__)
-        verify_dir = os.path.join(thisdir,'./Sedov_regression')
+        verify_dir = os.path.join(thisdir,'Sedov_regression')
 
         # Expected solution
         sol_expected = Solution()
-        sol_expected.read(1,path=verify_dir,file_format='hdf',read_aux=False)
+        sol_expected.read(1,path=verify_dir,file_format='hdf',read_aux=False, file_prefix='claw')
         assert sol_expected.t == 0.1
         expected_q = sol_expected.state.q
 
@@ -30,6 +30,7 @@ def test_sedov_and_hdf():
         sol_test = Solution()
         sol_test.read(1,path=controller.outdir,
                         file_format=controller.output_format,
+                        file_prefix='claw',
                         read_aux=False,
                         options=controller.output_options)
         test_q = sol_test.state.get_q_global()


### PR DESCRIPTION
Fixes #703 
- removed the typo in line 21 and set verify_dir to the correct location. 
- added `file_prefix='claw'` to `read` method calls in lines 25 and 31