### PR TITLE
Give a more helpful error message if petsc4py is not installed.

### DIFF
--- a/src/petclaw/solution.py
+++ b/src/petclaw/solution.py
@@ -9,8 +9,17 @@ class Solution(Solution):
 
     def get_read_func(self, file_format):
         from clawpack.petclaw import fileio
+
         if file_format == 'petsc':
-            return fileio.petsc.read
+            try:
+                import clawpack.petclaw.fileio
+                return clawpack.petclaw.fileio.petsc.read
+            except AttributeError as e:
+                try:
+                    from petsc4py import PETSc
+                except ImportError:
+                    raise ImportError("petsc4py is required for reading petsc format files, but petsc4py could not be imported.")
+                raise e
         elif file_format == 'hdf5':
             return fileio.hdf5.read
         else:

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -382,8 +382,15 @@ class Solution(object):
             import clawpack.pyclaw.fileio.hdf5
             return clawpack.pyclaw.fileio.hdf5.read
         elif file_format == 'petsc':
-            import clawpack.petclaw.fileio
-            return clawpack.petclaw.fileio.petsc.read
+            try:
+                import clawpack.petclaw.fileio
+                return clawpack.petclaw.fileio.petsc.read
+            except AttributeError as e:
+                try:
+                    from petsc4py import PETSc
+                except ImportError:
+                    raise ImportError("petsc4py is required for reading petsc format files, but petsc4py could not be imported.")
+                raise e
         elif file_format == 'forestclaw':
             import clawpack.forestclaw.fileio.ascii
             return clawpack.forestclaw.fileio.ascii.read


### PR DESCRIPTION
The code always tries to import the petsc format reading/writing routines at import time, and we don't want all of pyclaw to fail if petsc4py is not installed, so no error is raised then (only a debug log message).  Then when the user tries to read a file in petsc format, they get a cryptic message.  This patch checks if petsc4py is installed and informs the user of the problem (but only if/when they try to read a petsc formatted file).