### PR TITLE
Raise Warning if the Capacity Array is Not Set But mapc2p is solved #614

### DIFF
--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -419,6 +419,33 @@ class Solution(object):
         raise NotImplementedError("Direct solution plotting has not been " +
             "implemented as of yet, please refer to the plotting module for" +
             " how to plot solutions.")
+        
+class MyPyclaw(Solution):
+    def __init__(self, domain, state, use_petsc=False):
+        super(MyPyclaw, self).__init__(domain, state, use_petsc)
+
+        # Check if the mapping is specified
+        if self.domain.mapc2p is not None:
+            if self.domain.c_centers is None or self.domain.c_nodes is None:
+                raise ValueError("Capacity array must be set when mapc2p is specified.")
+
+        # Check if Capacity Array is not set but mapc2p is
+        if self.domain.mapc2p is not None and self.domain.c_centers is None:
+            import warnings
+            warnings.warn("Capacity array is not set, but mapc2p is specified. "
+                          "Make sure to set the capacity array using set_c_capacity().")
+
+    def set_c_capacity(self):
+       num_cells = self.domain.grid.num_cells_global
+
+    # Check if the capacity array is not already set
+    if self.domain.c_centers is None:
+        # Allocate memory for the capacity array
+        self.domain.c_centers = numpy.empty((num_cells[0], num_cells[1]), dtype=float)
+
+        # Initialize capacity array with some default values, modify as needed
+        self.domain.c_centers[:, :] = 1.0
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Class Hierarchy:

The existing code defines a base class Solution.
I modified the code which introduces a new class MyPyclaw, which is a subclass of the Solution class.

Initialization:

The __init__ method in MyPyclaw is modified to include additional checks related to the domain and state objects passed during initialization.
It checks if a mapping (mapc2p) is specified in the domain.
If mapc2p is specified, it ensures that the capacity array (c_centers and c_nodes) is also set. Otherwise, it raises a ValueError.

Capacity Array Check:

After the checks, it verifies whether the capacity array (c_centers) is set. If mapc2p is specified, but the capacity array is not set, a warning is issued using the warnings module. The warning suggests setting the capacity array using the set_c_capacity method.

set_c_capacity Method:

A new method set_c_capacity is introduced in the MyPyclaw class.
Inside this method, it checks if the capacity array is not already set.
If not set, it allocates memory for the capacity array based on the global number of cells in the grid (num_cells). It uses numpy to create an empty array.
The capacity array is initialized with some default values (in this case, all elements set to 1.0).