### PR TITLE
Remove the `py_dep` dependency from extension modules in pyclaw/meson.build

### DIFF
--- a/src/pyclaw/meson.build
+++ b/src/pyclaw/meson.build
@@ -266,7 +266,6 @@ foreach subpkg, module: fortran_extensions
       incdir_f2py / 'fortranobject.c',
       c_args: [numpy_nodepr_api],
       include_directories: inc_np,
-      dependencies : py_dep,
       subdir: 'clawpack/pyclaw/' + srcdir,
       install : true
     )
@@ -277,7 +276,6 @@ py.extension_module(
     'reconstruct', 
     ['limiters/weno/reconstruct.c'],
     include_directories: inc_np,
-    dependencies : py_dep,
     subdir: 'clawpack/pyclaw/limiters/weno',
     install : true
 )
@@ -303,7 +301,6 @@ py.extension_module(
   ext_name, [ext_srcs, f2py_srcs],
   incdir_f2py / 'fortranobject.c',
   include_directories: inc_np,
-  dependencies : py_dep,
   subdir: 'clawpack/pyclaw/examples/shallow_sphere',
   install : true
 )
@@ -325,7 +322,6 @@ py.extension_module(
   ext_name, [ext_srcs, f2py_srcs],
   incdir_f2py / 'fortranobject.c',
   include_directories: inc_np,
-  dependencies : py_dep,
   subdir: 'clawpack/pyclaw/examples/advection_reaction_2d',
   install : true
 )


### PR DESCRIPTION
This is only a minor cleanup, it doesn't change behavior. Adding the dependency isn't necessary since Meson 0.63: https://mesonbuild.com/Release-notes-for-0-63-0.html#python-extension-modules-now-depend-on-the-python-library-by-default