### PR TITLE
Revert "Correctly use the floor instead of rounding to determine gauge cell index"

### DIFF
--- a/src/pyclaw/geometry.py
+++ b/src/pyclaw/geometry.py
@@ -398,7 +398,7 @@ class Grid(object):
             # Check if gauge belongs to this grid:
             if all(self.lower[n]<=gauge[n]<self.upper[n] for n in range(self.num_dim)):
                 # Set indices relative to this grid
-                gauge_index = [int((gauge[n]-self.lower[n])//self.delta[n]))
+                gauge_index = [int(round((gauge[n]-self.lower[n])/self.delta[n]))
                                for n in range(self.num_dim)]
                 gauge_file_name = 'gauge'+'_'.join(str(coord) for coord in gauge)+'.txt'
                 self.gauge_file_names.append(gauge_file_name)


### PR DESCRIPTION
Reverts clawpack/pyclaw#730

Extra parenthesis.