### PR TITLE
trying to fix coverage

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Upload to Coveralls
       if: always()
       run: |
+        cd ${CLAW}/pyclaw
         ls -l .coverage
         coveralls
       env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -55,7 +55,7 @@ jobs:
         cd ${CLAW}/pyclaw
         coverage run --source=src -m pytest --ignore=development
 
-    -name: Upload to Coveralls
+    - name: Upload to Coveralls
       run: coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
         pip install 'numpy<2.0'
         pip install matplotlib #Some imports require matplotlib
         pip install scipy #To not skip tests
-        pip install flake8 meson-python ninja pytest
+        pip install flake8 meson-python ninja pytest coveralls
         # if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Checkout Clawpack
@@ -53,4 +53,7 @@ jobs:
     - name: Test with pytest
       run: |
         cd ${CLAW}/pyclaw
-        pytest --ignore=development
+        coverage run --source=src -m pytest --ignore=development
+        coveralls
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -60,3 +60,4 @@ jobs:
       run: coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -56,6 +56,7 @@ jobs:
         coverage run --source=src -m pytest --ignore=development
 
     - name: Upload to Coveralls
+      if: always()
       run: coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,7 +57,9 @@ jobs:
 
     - name: Upload to Coveralls
       if: always()
-      run: coveralls
+      run: |
+        ls -l .coverage
+        coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -54,6 +54,8 @@ jobs:
       run: |
         cd ${CLAW}/pyclaw
         coverage run --source=src -m pytest --ignore=development
-        coveralls
+
+    -name: Upload to Coveralls
+      run: coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status](https://github.com/clawpack/pyclaw/actions/workflows/testing.yml/badge.svg)](https://github.com/clawpack/pyclaw/actions)
-[![Coverage Status](https://img.shields.io/coveralls/clawpack/pyclaw.svg)](https://coveralls.io/r/clawpack/pyclaw?branch=master)
-
+[![Coverage Status](https://coveralls.io/repos/github/clawpack/pyclaw/badge.svg?branch=master)](https://coveralls.io/r/clawpack/pyclaw?branch=master)
 [![PyPI version](https://badge.fury.io/py/clawpack.svg)](https://badge.fury.io/py/clawpack)
 
 


### PR DESCRIPTION
The coverage badge is broken in the readme, and it looks like the last time coverage was successfully used was [2019](https://coveralls.io/github/clawpack/pyclaw)! I'm attempting a fix by following an old example of mine where I [figured this out](https://github.com/pavelkomarov/projection-pursuit/blob/master/.github/workflows/build.yml). I'll need one of you repo maintainers to sign in to the coverage account and generate a token and put it as a secret in this repo, or go look at the repo secrets and tell me what the token is named. (It may already exist.)