### PR TITLE
Automatically set solver.fwave based on values in Riemann repository.

### DIFF
--- a/examples/advection_reaction_2d/advection_reaction.py
+++ b/examples/advection_reaction_2d/advection_reaction.py
@@ -80,6 +80,7 @@ def setup(outdir='./_output'):
     domain = pyclaw.Domain( (0.,0.), (1.,1.), (100,100) )
     solver.num_eqn = 2
     solver.num_waves = 1
+    solver.fwave = False
     num_aux = 2
     state = pyclaw.State(domain, solver.num_eqn, num_aux)
 

--- a/src/pyclaw/solver.py
+++ b/src/pyclaw/solver.py
@@ -218,6 +218,7 @@ class Solver(object):
 
         self.num_eqn   = None
         self.num_waves = None
+        self.fwave = None
 
         self.compute_gauge_values = default_compute_gauge_values
         r"""(function) - Function that computes quantities to be recorded at gauges"""
@@ -234,6 +235,7 @@ class Solver(object):
                 rp_name = rp_name.replace("_ptwise", "")
             self.num_eqn   = riemann.static.num_eqn.get(rp_name,None)
             self.num_waves = riemann.static.num_waves.get(rp_name,None)
+            self.fwave = riemann.static.fwave.get(rp_name,None)
 
         self._isinitialized = True
 
@@ -273,6 +275,9 @@ class Solver(object):
         if self.num_eqn is None:
             valid = False
             reason = 'solver.num_eqn has not been set.'
+        if self.fwave is None:
+            valid = False
+            reason = 'solver.fwave has not been set.'
         if (None in self.bc_lower) or (None in self.bc_upper):
             valid = False
             reason = 'One of the boundary conditions has not been set.'


### PR DESCRIPTION
Also check if it's set when checking solver validity.

This addresses the first part of https://github.com/clawpack/pyclaw/issues/737 and must be used in combination with https://github.com/clawpack/riemann/pull/181, which adds the relevant values to the riemann repo.