### PR TITLE
Numpy frame

### DIFF
--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -138,7 +138,10 @@ class Solution(object):
             # Load frame
             frame = arg[0]
             if not isinstance(frame,numbers.Integral):
-                raise Exception('Invalid pyclaw.Solution object initialization')
+                raise Exception(
+                    'Invalid pyclaw.Solution object initialization: '
+                    + repr(frame) + ' is not an int.'
+                )
             if ('count_from_zero' in kargs):
                 if (kargs['count_from_zero'] == True):
                     self._start_frame = 0

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -137,11 +137,7 @@ class Solution(object):
         if len(arg) == 1:
             # Load frame
             frame = arg[0]
-            if not isinstance(frame,numbers.Integral):
-                raise Exception(
-                    'Invalid pyclaw.Solution object initialization: '
-                    + repr(frame) + ' is not an int.'
-                )
+            frame = int(frame)
             if ('count_from_zero' in kargs):
                 if (kargs['count_from_zero'] == True):
                     self._start_frame = 0
@@ -182,7 +178,7 @@ class Solution(object):
                 raise Exception("Invalid arguments for Solution initialization.")
         elif len(arg) == 0:
             if 'frame' in kargs:
-                frame = kargs.pop('frame')
+                frame = int(kargs.pop('frame'))
                 self.read(frame,**kargs)
             elif not kargs:
                 pass  # With no arguments, initialize empty solution

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -6,6 +6,7 @@ Module containing all Pyclaw solution objects
 
 import os
 import logging
+import numbers
 
 from .geometry import Patch, Dimension, Domain
 
@@ -136,7 +137,7 @@ class Solution(object):
         if len(arg) == 1:
             # Load frame
             frame = arg[0]
-            if not isinstance(frame,int):
+            if not isinstance(frame,numbers.Integral):
                 raise Exception('Invalid pyclaw.Solution object initialization')
             if ('count_from_zero' in kargs):
                 if (kargs['count_from_zero'] == True):

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -135,8 +135,7 @@ class Solution(object):
         self.domain = None
         if len(arg) == 1:
             # Load frame
-            frame = arg[0]
-            frame = int(frame)
+            frame = int(arg[0])
             if ('count_from_zero' in kargs):
                 if (kargs['count_from_zero'] == True):
                     self._start_frame = 0

--- a/src/pyclaw/solution.py
+++ b/src/pyclaw/solution.py
@@ -6,7 +6,6 @@ Module containing all Pyclaw solution objects
 
 import os
 import logging
-import numbers
 
 from .geometry import Patch, Dimension, Domain
 


### PR DESCRIPTION
Hi everyone!

I spent too much time on the error below that showed up because I gave the `frame` argument of `pyclaw.solution.Solution.__init__` a numpy integer instead of a pure python integer... So I thought it could be made a bit more flexible.

```
type(frame) = <class 'numpy.int64'>
Traceback (most recent call last):
  File "/home/giboul/Desktop/TriftGeoClaw/TSUL/read.py", line 114, in <module>
    read_cut(times[i])
  File "/home/giboul/Desktop/TriftGeoClaw/TSUL/read.py", line 71, in read_cut
    frame_sol = solution.Solution(frame, path=projdir/"AVAC"/"_output5", file_format=AVAC["out_format"])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giboul/Desktop/clawpack/pyclaw/src/pyclaw/solution.py", line 140, in __init__
    raise Exception('Invalid pyclaw.Solution object initialization')
Exception: Invalid pyclaw.Solution object initialization
```

With the suggested changes, the error message would look like this for an erroneous input:

```type(frame) = <class 'str'>
Traceback (most recent call last):
  File "/home/giboul/Desktop/TriftGeoClaw/TSUL/read.py", line 114, in <module>
    read_cut(times[i])
  File "/home/giboul/Desktop/TriftGeoClaw/TSUL/read.py", line 71, in read_cut
    frame_sol = solution.Solution(frame, path=projdir/"AVAC"/"_output5", file_format=AVAC["out_format"])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/giboul/Desktop/clawpack/pyclaw/src/pyclaw/solution.py", line 141, in __init__
    raise Exception(
Exception: Invalid pyclaw.Solution object initialization: '...' is not an int.
```

