### PR TITLE
Fix #740: file_prefix argument is inconsistently implemented in fileio.ascii.py

### DIFF
--- a/src/pyclaw/fileio/ascii.py
+++ b/src/pyclaw/fileio/ascii.py
@@ -50,7 +50,7 @@ def write(solution, frame, path, file_prefix='fort', write_aux=False,
         f.write("%s                  file_format\n" % "ascii")
 
     # Write fort.qxxxx file
-    file_name = 'fort.q%s' % str(frame).zfill(4)
+    file_name = '%s.q%s' % (file_prefix,str(frame).zfill(4))
     with open(os.path.join(path,file_name),'w') as q_file:
         for state in solution.states:
             write_patch_header(q_file,state.patch)
@@ -62,7 +62,7 @@ def write(solution, frame, path, file_prefix='fort', write_aux=False,
 
     # Write fort.auxxxxx file if required
     if solution.num_aux > 0 and write_aux:
-        file_name = 'fort.a%s' % str(frame).zfill(4)
+        file_name = '%s.a%s' % (file_prefix,str(frame).zfill(4))
         with open(os.path.join(path,file_name),'w') as aux_file:
             for state in solution.states:
                 write_patch_header(aux_file,state.patch)


### PR DESCRIPTION
Hello,
Hope you're doing well
As it has been requested in #740, I have eliminated the hard-coded substring `fort` and injected the `file_prefix` variable instead to lines 53 and 65 respectively
Kindly let me know if the code changes meet the requirements
Sincere apologies for my mistakes if you find any

Thanks and Regards,
Mohit Kambli