### PR TITLE
move read_t to binary.py namespace

### DIFF
--- a/src/pyclaw/fileio/binary.py
+++ b/src/pyclaw/fileio/binary.py
@@ -13,6 +13,7 @@ import logging
 from ..util import read_data_line
 import numpy as np
 import clawpack.pyclaw as pyclaw
+from clawpack.pyclaw.fileio.ascii import read_t
 
 logger = logging.getLogger('pyclaw.fileio')
 
@@ -42,7 +43,7 @@ def read(solution,frame,path='./',file_prefix='fort',read_aux=False,
      - *options* - (dict) Dictionary of optional arguments dependent on 
        the format being read in.  ``default = {}``
     """
-    from clawpack.pyclaw.fileio.ascii import read_t
+    
     
     # Construct path names
     base_path = os.path.join(path,)


### PR DESCRIPTION
Addresses #744 by moving `read_t` such that it is in the module namespace. I'm not aware of why `read_t` was imported within the `read` function to begin with, so I'm not sure if this is going to create other issues. Someone with more of an understanding of `pyclaw` should probably take a look at this before anything gets merged.