### PR TITLE
Raise Warning if the Capacity Array is Not Set But mapc2p is 

### DIFF
--- a/src/petclaw/state.py
+++ b/src/petclaw/state.py
@@ -114,7 +114,22 @@ class State(clawpack.pyclaw.State):
     @property
     def num_dim(self):
         return self.patch.num_dim
-
+    
+    @property
+    def index_capa(self):
+        r"""(int) - Index of capacity function in aux array, or -1 if none."""
+        if self.grid.mapc2p is None:
+            raise ValueError("Capacity function index requested but no mapping defined.")
+        else:
+            return self._index_capa
+    @index_capa.setter
+    def index_capa(self,index):
+        if self.aux is None:
+            raise Exception("Cannot set capacity function index before aux array is initialized.")
+        elif index < -1 or index >= self.num_aux:
+            raise Exception("Capacity function index out of range.")
+        else:
+            self._index_capa = index
 
     def __init__(self,geom,num_eqn,num_aux=0):
         r"""
@@ -150,7 +165,7 @@ class State(clawpack.pyclaw.State):
         self.t=0.
         r"""(float) - Current time represented on this patch, 
             ``default = 0.0``"""
-        self.index_capa = -1
+        self._index_capa = -1
         self.keep_gauges = False
         r"""(bool) - Keep gauge values in memory for every time step, 
         ``default = False``"""

--- a/src/pyclaw/state.py
+++ b/src/pyclaw/state.py
@@ -114,6 +114,22 @@ class State(object):
             raise Exception('Cannot change state.mF after aux is initialized.')
         else:
             self.F = self.new_array(mF)
+    
+    @property
+    def index_capa(self):
+        r"""(int) - Index of capacity function in aux array, or -1 if none."""
+        if self.grid.mapc2p is None:
+            raise ValueError("Capacity function index requested but no mapping defined.")
+        else:
+            return self._index_capa
+    @index_capa.setter
+    def index_capa(self,index):
+        if self.aux is None:
+            raise Exception("Cannot set capacity function index before aux array is initialized.")
+        elif index < -1 or index >= self.num_aux:
+            raise Exception("Capacity function index out of range.")
+        else:
+            self._index_capa = index
 
     # ========== Class Methods ===============================================
     def __init__(self,geom,num_eqn,num_aux=0):
@@ -138,7 +154,7 @@ class State(object):
         self.t=0.
         r"""(float) - Current time represented on this patch, 
             ``default = 0.0``"""
-        self.index_capa = -1
+        self._index_capa = -1
         self.keep_gauges = False
         r"""(bool) - Keep gauge values in memory for every time step, 
         ``default = False``"""


### PR DESCRIPTION

Changes:
  - added property index_capa with setter to introduce ValueError if the mapc2p is not set.
  - also indruduces Exception in setter so aux is set and the index is not out of bounce.
  - made variable self.index_capa private, so the property is used instead.

I made these changes twice. Once in the [petclaw](src/petclaw) and in the [pyclaw](src/pyclaw) directory, because there is a state file in both directories. For my understanding it was necessary to introduce this error in a state level, otherwise you couldn't check the grid and the array. 
I also made it a error instead of a warning because the simulation should break, when mapc2p is not set, because the simulation can't run without it. 