### PR TITLE
Fix signature Domain.__init__ and quadrants format

### DIFF
--- a/examples/euler_2d/quadrants.py
+++ b/examples/euler_2d/quadrants.py
@@ -117,7 +117,8 @@ def setup(use_petsc=False,riemann_solver='roe'):
     claw.solution = solution
     claw.solver = solver
 
-    claw.output_format = 'ascii'    
+    if not use_petsc:
+        claw.output_format = 'ascii'   
     claw.outdir = "./_output"
     claw.keep_copy = True
     claw.setplot = setplot

--- a/src/petclaw/geometry.py
+++ b/src/petclaw/geometry.py
@@ -81,13 +81,25 @@ class Domain(pyclaw_geometry.Domain):
 
     __doc__ += pyclaw.util.add_parent_doc(pyclaw.ClawSolver2D)
 
-    def __init__(self,geom):
-        if not isinstance(geom,list):
-            geom = [geom]
-        if isinstance(geom[0],Patch):
-            self.patches = geom
-        elif isinstance(geom[0],pyclaw_geometry.Dimension):
-            self.patches = [Patch(geom)]
+    def __init__(self,*arg):
+        if len(arg)>1:
+            lower = arg[0]
+            upper = arg[1]
+            n     = arg[2]
+            dims = []
+            names = ['x','y','z']
+            names = names[:len(n)+1]
+            for low,up,nn,name in zip(lower,upper,n,names):
+                dims.append(Dimension(low,up,nn,name=name))
+            self.patches = [Patch(dims)]
+        else:
+            geom = arg[0]
+            if not isinstance(geom,list) and not isinstance(geom,tuple):
+                geom = [geom]
+            if isinstance(geom[0],Patch):
+                self.patches = geom
+            elif isinstance(geom[0],pyclaw_geometry.Dimension):
+                self.patches = [Patch(geom)]
 
 class Dimension(pyclaw_geometry.Dimension):
     def __init__(self, lower, upper, num_cells, name='x',


### PR DESCRIPTION
This PR fixes two small issues:

- When using PETSc, the example `examples/euler_2d/quadrants.py` throws an error since PetClaw's geometry.Domain.__init__ is not safeguarded against an instantiation like: `domain = pyclaw.Domain([0.,0.],[1.,1.],[100,100])`, which is accepted in the serial version.
- This example also throws an error since `'ascii'` was the default format even when using PETSc.

Maybe we could include a couple of PetClaw runs in the CI testing workflow to catch more of these.